### PR TITLE
Update to Infinispan 6.0.0.Final

### DIFF
--- a/carmart-tx/pom.xml
+++ b/carmart-tx/pom.xml
@@ -29,7 +29,7 @@
         <version.jboss.weld>1.1.8.Final</version.jboss.weld>
         <version.com.sun.faces.jsf.impl>2.0.2</version.com.sun.faces.jsf.impl>
 
-        <version.org.infinispan>6.0.0.CR1</version.org.infinispan>
+        <version.org.infinispan>6.0.0.Final</version.org.infinispan>
 
         <version.jboss.spec.javaee.6.0>3.0.2.Final</version.jboss.spec.javaee.6.0>
 

--- a/carmart/pom.xml
+++ b/carmart/pom.xml
@@ -34,7 +34,7 @@
             can deploy this quickstart on EWS/Tomcat through this URL -->
         <tomcat.management.url>http://localhost:8080/manager/text</tomcat.management.url>
 
-        <version.org.infinispan>6.0.0.CR1</version.org.infinispan>
+        <version.org.infinispan>6.0.0.Final</version.org.infinispan>
 
         <version.jboss.spec.javaee.6.0>3.0.2.Final</version.jboss.spec.javaee.6.0>
 

--- a/helloworld-jdg/pom.xml
+++ b/helloworld-jdg/pom.xml
@@ -27,7 +27,7 @@
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
-        <version.org.infinispan>6.0.0.CR1</version.org.infinispan>
+        <version.org.infinispan>6.0.0.Final</version.org.infinispan>
 
         <version.jboss.spec.javaee.6.0>3.0.2.Final</version.jboss.spec.javaee.6.0>
 

--- a/hotrod-endpoint/pom.xml
+++ b/hotrod-endpoint/pom.xml
@@ -43,10 +43,9 @@
             command -->
         <main.class.hotrod-endpoint>org.jboss.as.quickstarts.datagrid.hotrod.FootballManager</main.class.hotrod-endpoint>
 
-        <version.org.infinispan>6.0.0.CR1</version.org.infinispan>
+        <version.org.infinispan>6.0.0.Final</version.org.infinispan>
 
         <!-- other plugin versions -->
-        <shade.plugin.version>1.5</shade.plugin.version>
         <exec.plugin.version>1.2.1</exec.plugin.version>
         <ant.plugin.version>1.7</ant.plugin.version>
 


### PR DESCRIPTION
- removed maven shade version property since it's no longer needed
