### PR TITLE
Add a example for EAP applications with embedded JDG caches

### DIFF
--- a/eap-cluster-app/README.md
+++ b/eap-cluster-app/README.md
@@ -1,0 +1,190 @@
+eap-cluster-app: Example how to use JDG cache from a EAP application
+====================================================================
+Author: Wolf-Dieter Fink
+Level: Advanced
+Technologies: Infinispan, CDI, EAP
+Summary: Shows how to use Infinispan from a EAP application in embedded mode
+Target Product: JDG
+Product Versions: EAP 6.x, JDG 6.3
+Source: <https://github.com/infinispan/jdg-quickstart>
+
+What is it?
+-----------
+
+EAP-cluster-app demonstrates how to use a Infinispan Cache in embedded mode inside of a Java EE application
+deployed at an EAP6 server.
+There are three different applications do show:
+- how to create and use a JDG clustered cache without having a EAP cluster
+- An EAP cluster is independend from a JDG cluster
+- One EAP instance can use different JDG caches which are member of different JDG clusters
+- Programmatic cache configuration using the Infinispan API
+- File based configuration (administration application App1Cache)
+- Use CDI to inject the cache managers
+
+Each application contains a embedded JDG cache which is accessed by stateless EJB's in the same application.
+The different EAP servers, except AppTwo, are not clustered to show that an unclustered application can share the JDG cache.
+There are two cache managers used which are not part of the same JDG cluster.
+The AdminApp is able to access both caches and change the entries.
+AppOne can only read the App1Cache and use a clustered EJB invocation to AppTwo to read from App2Cache.
+AppTwo is deployed as a clustered EJB application and only read App2Cache.
+
+All applications need to have a installed JDG 6.3 module extention for the EAP server which can be downloaded from the Red Hat portal.
+
+
+System requirements
+-------------------
+
+All you need to build this project is Java 6.0 (Java SDK 1.6) or better, Maven 3.0 or better.
+
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform (EAP) 6.1 or later.
+
+ 
+Configure Maven
+---------------
+
+If you have not yet done so, you must [Configure Maven](../../README.md#configure-maven) before testing the quickstarts.
+
+
+Configure and start EAP instances in standanlone mode
+-----------------------------------------------------
+
+1. Prepare a copy of the EAP
+   - unzip jboss-datagrid-6.3.0.Beta-eap-modules-library.zip
+   - copy the modules to the server modules directory
+
+        For Linux:   cp -a jboss-datagrid-6.3.0.Beta-eap-modules-library/modules/org $EAP_HOME/modules
+        For Windows: xcopy /e/i/f jboss-datagrid-6.3.0.Beta-eap-modules-library/modules %EAP_NODE1_HOME%\modules
+
+   - Add a user to each server for ejb access
+
+        For Linux:   $EAP_NODE#_HOME/bin/add-user.sh -a -u quickuser -p quick-123
+        For Windows: %EAP_NODE#_HOME%\bin\add-user.bat -a -u quickuser -p quick-123
+
+2. Copy the prepared EAP server to 4 different directories EAP_NODE[1-4].
+3. Open a command line for each of the 4 nodes and navigate to the root of the EAP server directory.
+   The following shows the command line to start the different servers:
+
+        For Linux:   $EAP_NODE1_HOME/bin/standalone.sh -Djboss.node.name=node1
+                     $EAP_NODE2_HOME/bin/standalone.sh -Djboss.node.name=node2 -Djboss.socket.binding.port-offset=100
+                     $EAP_NODE3_HOME/bin/standalone.sh -Djboss.node.name=node3 -Djboss.socket.binding.port-offset=200 -c standalone-ha.xml
+                     $EAP_NODE4_HOME/bin/standalone.sh -Djboss.node.name=node4 -Djboss.socket.binding.port-offset=300 -c standalone-ha.xml
+        For Windows: %EAP_NODE1_HOME%\bin\standalone.bat -Djboss.node.name=node1
+                     %EAP_NODE2_HOME%\bin\standalone.sh -Djboss.node.name=node2 -Djboss.socket.binding.port-offset=100
+                     %EAP_NODE3_HOME%\bin\standalone.sh -Djboss.node.name=node3 -Djboss.socket.binding.port-offset=200 -c standalone-ha.xml
+                     %EAP_NODE4_HOME%\bin\standalone.sh -Djboss.node.name=node4 -Djboss.socket.binding.port-offset=300 -c standalone-ha.xml
+
+
+4. Add the configuration for node2 (AppOne) to use EJB server-to-server invocation:
+
+        For Linux:   $EAP_NODE2_HOME/bin/jboss-cli.sh -c --file=$QUICKSTART_HOME/install-appOne-standalone.cli
+        For Windows: %EAP_NODE2_HOME%\bin\jboss-cli.bat -c --file=%QUICKSTART_HOME%/install-appOne-standalone.cli
+
+5. Copy the application to the appropriate server
+
+        cp adminApp/ear/target/jboss-eap-application-adminApp.ear EAP_NODE1/standalone/deployments
+        cp cp appOne/ear/target/jboss-eap-application-AppOne.ear EAP_NODE2/standalone/deployments
+        cp cp appTwo/ear/target/jboss-eap-application-AppTwo.ear EAP_NODE3/standalone/deployments
+        cp appTwo/ear/target/jboss-eap-application-AppTwo.ear EAP_NODE4/standalone/deployments
+
+
+Configure and start EAP in domain mode
+--------------------------------------
+
+1. Copy a fresh EAP installation to $EAP_HOME
+2. Open a command line and navigate to the root of the EAP directory.
+3. Add a user:
+
+        For Linux:   $EAP_HOME/bin/add-user.sh -a -u quickuser -p quick-123
+        For Windows: %EAP_HOME%\bin\add-user.bat -a -u quickuser -p quick-123
+
+4. The following shows the command line to start the domain:
+
+        For Linux:   $EAP_HOME/bin/domain.sh
+        For Windows: %EAP_HOME%\bin\domain.bat
+
+5. Apply the configuration for the quickstart, the domain will contain 4 nodes:
+
+        For Linux:   $EAP_HOME/bin/jboss-cli.sh -c --file=$QUICKSTART_HOME/install-domain.cli
+        For Windows: %EAP_HOME%\bin\jboss-cli.bat -c --file=%QUICKSTART_HOME%/install-domain.cli
+
+
+
+Build the Application
+------------------------------------------------
+
+_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See [Build and Deploy the Quickstarts](../README.md#build-and-deploy-the-quickstarts) for complete instructions and additional options._
+
+1. Open a command line and navigate to the root directory of this quickstart.
+2. Type this command to build and deploy the archive:
+
+        mvn clean install
+        
+3. Copy the application to the appropriate server
+
+        For Linux:   cp adminApp/ear/target/jboss-eap-application-adminApp.ear EAP_NODE1/standalone/deployments
+                     cp appOne/ear/target/jboss-eap-application-AppOne.ear EAP_NODE2/standalone/deployments
+                     cp appTwo/ear/target/jboss-eap-application-AppTwo.ear EAP_NODE3/standalone/deployments
+                     cp appTwo/ear/target/jboss-eap-application-AppTwo.ear EAP_NODE4/standalone/deployments
+        For Windows: copy adminApp\ear\target\jboss-eap-application-adminApp.ear %EAP_NODE1%\standalone\deployments
+                     copy appOne\ear\target\jboss-eap-application-AppOne.ear %EAP_NODE2%\standalone\deployments
+                     copy appTwo\ear\target\jboss-eap-application-AppTwo.ear %EAP_NODE3%\standalone\deployments
+                     copy appTwo\ear\target\jboss-eap-application-AppTwo.ear %EAP_NODE4%\standalone\deployments
+ 
+6. Deploy the applications to the domain:
+
+        For Linux:   $EAP_HOME/bin/jboss-cli.sh -c --file=$QUICKSTART_HOME/deploy-domain.cli
+        For Windows: %EAP_HOME%\bin\jboss-cli.bat -c --file=%QUICKSTART_HOME%/deploy-domain.cli
+
+
+
+Access the application
+----------------------
+
+To start the different following applications you need to navigate to the client directory of this quickstart.
+
+
+Step 1: Add values to App1 cache with the AdminApp and validate that they are replicated to the server instance of AppOne.
+        Add a value to App2 cache, rollback the transaction and check that it is not added to the cache after rollback.
+        The AdminServer and the AppOneServer are not configured as EAP cluster, only the JDG caches are configured by the application
+        to communicate and replicate the caches.
+
+        mvn -Dexec.mainClass=org.jboss.as.quickstarts.datagrid.eap.app.AdminClient exec:java
+
+To add more instances it is possible to overwrite the used connections by adding the following argument
+
+        mvn -Dexec.args="AdminHost AdminPort AppOneHost AppOnePort" ....
+
+The defaults are "locahost 4447 localhost 4547"
+
+  The console output show the actions and results, any unexpected result will show an Exception 
+         Add a value to App1Cache with the AdminApp and check on the same instance that the value is correct added
+           success
+         Check the previous added value of App1Cache by accessing the AppOne Server
+           success
+         Add a value to App2Cache and check on the same instance that the value is correct added
+           success
+         Check whether changes to a cache are rollbacked if the transaction fail
+           The cache App2 work as expected on rollback
+
+Step 2: Add values to App2 cache with the AdminApp and acess AppOne to show that the EJB invocation is clustered and both AppTwo instances are used.
+        Show that the EAP and JDG clusters are not related and the JDG cluster is able to use a different JDG/JGroups implementation
+        as the EAP server.
+
+        mvn -Dexec.mainClass=org.jboss.as.quickstarts.datagrid.eap.app.AppOneClient exec:java
+
+  The console output show the actions and results, any unexpected result will show an Exception 
+        Add a value to App2Cache with the AdminApp
+        Access the App2Cache from the AppOneServer by using the clustered EJB@AppTwoServer
+          success : received the following node names for EJB invocation : [node3, node4]
+
+
+
+
+Debug the Application
+---------------------
+
+If you want to debug the source code or look at the Javadocs of any library in the project, run either of the following commands to pull them into your local repository. The IDE should then detect them.
+
+        mvn dependency:sources
+        mvn dependency:resolve -Dclassifier=javadoc
+

--- a/eap-cluster-app/adminApp/ear/pom.xml
+++ b/eap-cluster-app/adminApp/ear/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.quickstarts.jdg</groupId>
+        <artifactId>jboss-eap-application-adminApp</artifactId>
+        <version>6.3.0-redhat-SNAPSHOT</version>
+    </parent>
+    <artifactId>jboss-eap-application-adminApp-ear</artifactId>
+    <packaging>ear</packaging>
+    <name>JBoss JDG Quickstart: jboss-eap-application - adminApp ear</name>
+    <description>Create the deployable application archive
+     Include the EJB and ISPN application together with the necessary API libraries
+  </description>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+    <dependencies>
+        <!-- add the EJB and WEB project as dependency to include it in the EAR -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-eap-application-adminApp-ejb</artifactId>
+            <type>ejb</type>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-ejb-client-bom</artifactId>
+            <scope>provided</scope>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <!-- define the name for the deployable archive instead of using the default name with the version -->
+        <finalName>${project.parent.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>${ear.plugin.version}</version>
+                <configuration>
+                    <displayName>Admin Application</displayName>
+                    <description>A simple quickstart application to demonstrate the
+                        use of JDG inside of an EAP application</description>
+                    <version>6</version>
+                    <generateApplicationXml>false</generateApplicationXml>
+                    <modules>
+                        <ejbModule>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>jboss-eap-application-adminApp-ejb</artifactId>
+                            <bundleFileName>ejb.jar</bundleFileName>
+                        </ejbModule>
+                    </modules>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources/META-INF</directory>
+                <!-- add the classloading configuration -->
+                <includes>
+                    <include>*.xml</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/eap-cluster-app/adminApp/ear/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/eap-cluster-app/adminApp/ear/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,10 @@
+<jboss-deployment-structure>
+
+    <ear-subdeployments-isolated>true</ear-subdeployments-isolated>
+    <sub-deployment name="ejb.jar">
+        <!-- use the provided JDG modules  -->
+        <dependencies>
+            <module name="org.infinispan" slot="jdg-6.3" services="export"/>
+        </dependencies>
+    </sub-deployment>
+</jboss-deployment-structure>

--- a/eap-cluster-app/adminApp/ejb/pom.xml
+++ b/eap-cluster-app/adminApp/ejb/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.quickstarts.jdg</groupId>
+        <artifactId>jboss-eap-application-adminApp</artifactId>
+        <version>6.3.0-redhat-SNAPSHOT</version>
+    </parent>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <artifactId>jboss-eap-application-adminApp-ejb</artifactId>
+
+    <name>JBoss JDG Quickstart: jboss-eap-application - adminApp ejb</name>
+    <url>http://maven.apache.org</url>
+    <packaging>ejb</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-ejb-client-bom</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <!-- For JDG caches -->
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>  <!-- must include ejb-plugin to change the EJB version from 2.1 to 3.1 -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ejb-plugin</artifactId>
+                <version>${ejb.plugin.version}</version>
+                <configuration>
+                    <ejbVersion>3.1</ejbVersion>
+                    <generateClient>true</generateClient>
+                    <clientExcludes>
+                        <!-- ensure that the classes for injection are not provided -->
+                        <clientExclude>**/Resources*</clientExclude>
+                        <clientExclude>**/*Provider*</clientExclude>
+                        <clientExclude>**/*Bean*</clientExclude>
+                        <clientExclude>jgroups-udp.xml</clientExclude>
+                        <clientExclude>META-INF/*</clientExclude>
+                    </clientExcludes>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/App1Cache.java
+++ b/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/App1Cache.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import static java.lang.annotation.ElementType.*;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * Qualifier for CDI to select the appropriate application cache for injection.
+ * 
+ * @author "Wolf-Dieter Fink"
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ METHOD })
+public @interface App1Cache {
+}

--- a/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/App1CacheManagerProvider.java
+++ b/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/App1CacheManagerProvider.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.infinispan.manager.DefaultCacheManager;
+
+/**
+ * Creates a DefaultCacheManager which is configured with a configuration file.
+ * <b>Infinispan's libraries need to be provided as module with dependency, also bundling with the application is possible.</b>
+ * 
+ * @author Wolf-Dieter Fink
+ */
+@ApplicationScoped
+public class App1CacheManagerProvider {
+   private static final String CONFIG = "apponecache-config.xml";
+   private static final Logger log = Logger.getLogger(App1CacheManagerProvider.class.getName());
+   private DefaultCacheManager manager;
+
+   public DefaultCacheManager getCacheManager() {
+      if (manager == null) {
+         log.info("construct a App1CacheManager");
+
+         try {
+            manager = new DefaultCacheManager(CONFIG, true);
+         } catch (IOException e) {
+            log.log(Level.SEVERE, "Could not read " + CONFIG + " to create the App1CacheManager", e);
+         }
+      }
+      return manager;
+   }
+
+   @PreDestroy
+   public void cleanUp() {
+      manager.stop();
+      manager = null;
+   }
+
+}

--- a/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/App2Cache.java
+++ b/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/App2Cache.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import static java.lang.annotation.ElementType.*;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * Qualifier for CDI to select the appropriate application cache for injection.
+ * 
+ * @author "Wolf-Dieter Fink"
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({FIELD, METHOD})
+public @interface App2Cache {
+}

--- a/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/App2CacheManagerProvider.java
+++ b/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/App2CacheManagerProvider.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import java.util.logging.Logger;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.transaction.lookup.GenericTransactionManagerLookup;
+
+/**
+ * Creates a DefaultCacheManager which is configured with a configuration file.
+ * <b>Infinispan's libraries need to be provided as module with dependency, also bundling with the application is possible.</b>
+ * 
+ * @author Wolf-Dieter Fink
+ */
+@ApplicationScoped
+public class App2CacheManagerProvider {
+   private static final Logger log = Logger.getLogger(App2CacheManagerProvider.class.getName());
+   private DefaultCacheManager manager;
+
+   public DefaultCacheManager getCacheManager() {
+      if (manager == null) {
+         log.info("construct a App2CacheManager");
+
+         GlobalConfiguration glob = new GlobalConfigurationBuilder().clusteredDefault() // Builds a default clustered
+               // notice the file MUST NOT named jgroups-udp.xml as this is provided by the infinispan module and prefered !
+               .transport().addProperty("configurationFile", "jgroups-admin.xml") // provide a specific JGroups configuration
+               .clusterName("ClusterTwo").globalJmxStatistics().allowDuplicateDomains(true).enable() // This method enables the jmx statistics of
+               // the global configuration and allows for duplicate JMX domains
+               .build(); // Builds the GlobalConfiguration object
+         Configuration loc = new ConfigurationBuilder().jmxStatistics().enable() // Enable JMX statistics
+               .clustering().cacheMode(CacheMode.DIST_SYNC) // Set Cache mode to SYNC DISTRIBUTED
+               .build();
+         manager = new DefaultCacheManager(glob, loc, true);
+
+         Configuration cache = new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_SYNC).transaction()
+               .transactionMode(TransactionMode.TRANSACTIONAL)
+               .transactionManagerLookup(new GenericTransactionManagerLookup()).build();
+         manager.defineConfiguration("App2Cache", cache);
+      }
+      return manager;
+   }
+
+   @PreDestroy
+   public void cleanUp() {
+      manager.stop();
+      manager = null;
+   }
+
+}

--- a/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/CacheAdmin.java
+++ b/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/CacheAdmin.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import javax.ejb.Remote;
+
+@Remote
+public interface CacheAdmin {
+
+   /**
+    * Add the given entry to the App1Cache
+    */
+   void addToApp1Cache(String key, String value);
+
+   /**
+    * Read from the App1Cache
+    * 
+    * @param key
+    *           the key for the entry to read
+    * @return the value for the given key
+    */
+   String getFromApp1Cache(String key);
+
+   /**
+    * Checks whether the given entry with key contains the value in App1Cache
+    * 
+    * @param key
+    * @param value
+    */
+   void verifyApp1Cache(String key, String value);
+
+   /**
+    * Checks whether the given entry with key contains the value in App2Cache
+    * 
+    * @param key
+    * @param value
+    */
+   void verifyApp2Cache(String key, String value);
+
+   /**
+    * Add the given entry to the App2Cache
+    */
+   void addToApp2Cache(String key, String value);
+
+   /**
+    * Add the given entry to the App2Cache and let the transaction fail if requested. As the
+    * App2Cache is transactional the entry should not exists if the transaction of the method is
+    * marked for rollback after the entry is added to the cache.
+    * 
+    * @param key
+    * @param value
+    * @param transactionFailure
+    *           If <code>true</code> the transaction will be marked as rollbackOnly
+    */
+   void addToApp2Cache(String key, String value, boolean transactionFailure);
+
+   /**
+    * Check whether the App2Cache contain a entry with the given key
+    * 
+    * @param key
+    *           the key for the entry to check
+    * @return <code>true</code> if the entry exists
+    */
+   boolean containsApp2Key(String key);
+
+   /**
+    * Delete the entry from cache
+    * 
+    * @param key
+    *           entry key which should be removed
+    */
+   void removeFromApp2Cache(String key);
+}

--- a/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/CacheAdminBean.java
+++ b/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/CacheAdminBean.java
@@ -1,0 +1,139 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.inject.Inject;
+
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.jboss.logging.Logger;
+
+/**
+ * <p>
+ * The administration bean called by the standalone client.
+ * </p>
+ * <p>
+ * Used to create check and remove entries to the different caches
+ * </p>
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+@Stateless
+public class CacheAdminBean implements CacheAdmin {
+   private static final Logger LOGGER = Logger.getLogger(CacheAdminBean.class);
+   @Resource
+   SessionContext context;
+
+   @Inject
+   DefaultCacheManager app1CacheManager;
+
+   @Inject
+   @App2Cache
+   DefaultCacheManager app2CacheManager;
+
+   /**
+    * Initialize and store the context for the EJB invocations.
+    */
+   @PostConstruct
+   public void init() {
+      LOGGER.info("CacheManagers:");
+      LOGGER.info("App1 " + app1CacheManager);
+      LOGGER.info("App2 " + app2CacheManager);
+   }
+
+   @Override
+   public void addToApp1Cache(String key, String value) {
+      LOGGER.info("addTo app1Cache (" + key + "," + value + ")");
+      Cache<String, String> cache = app1CacheManager.getCache("App1Cache");
+      cache.put(key, value);
+   }
+
+   @Override
+   public void verifyApp1Cache(String key, String value) {
+      Cache<String, String> cache = app1CacheManager.getCache("App1Cache");
+      final String cacheValue = cache.get(key);
+      if ((value == null && cacheValue != null) || (value != null && !value.equals(cacheValue))) {
+         throw new IllegalStateException("The given key/value pair does not match the cache!");
+      }
+   }
+
+   @Override
+   public String getFromApp1Cache(String key) {
+      LOGGER.info("getFrom progCache(" + key + ")");
+      Cache<String, String> cache = app1CacheManager.getCache("App1Cache");
+      final String value = cache.get(key);
+      LOGGER.info("value=" + value);
+
+      final String nodeName = System.getProperty("jboss.node.name");
+      return "Read app1Cache for key=" + key + " at server '" + nodeName + "' and get "
+            + (value == null ? "no value" : "value=" + value);
+   }
+
+   @Override
+   public void addToApp2Cache(String key, String value) {
+      LOGGER.info("addTo app2Cache (" + key + "," + value + ")");
+      Cache<String, String> cache = app2CacheManager.getCache("App2Cache");
+      cache.put(key, value);
+   }
+
+   @Override
+   public void removeFromApp2Cache(String key) {
+      LOGGER.info("removeFrom app2Cache (" + key + ")");
+      Cache<String, String> cache = app2CacheManager.getCache("App2Cache");
+      cache.remove(key);
+   }
+
+   @Override
+   @TransactionAttribute(TransactionAttributeType.REQUIRED)
+   public void addToApp2Cache(String key, String value, boolean transactionFailure) {
+      Cache<String, String> cache = app2CacheManager.getCache("App2Cache");
+      if (transactionFailure && cache.containsKey(key)) {
+         // ensure that the key does not exists before we add it 
+         throw new IllegalStateException("Key " + key + " exists!");
+      }
+      addToApp2Cache(key, value);
+
+      if (transactionFailure) {
+         // set the rollback flag and let the transaction fail
+         context.setRollbackOnly();
+      }
+   }
+
+   @Override
+   public boolean containsApp2Key(String key) {
+      Cache<String, String> cache = app2CacheManager.getCache("App2Cache");
+      final boolean contains = cache.containsKey(key);
+      LOGGER.info("app2Cache " + (contains ? "" : "does not ") + "contain a entity with key=" + key);
+      return contains;
+   }
+
+   @Override
+   public void verifyApp2Cache(String key, String value) {
+      Cache<String, String> cache = app2CacheManager.getCache("App2Cache");
+      final String cacheValue = cache.get(key);
+      if ((value == null && cacheValue != null) || (value != null && !value.equals(cacheValue))) {
+         throw new IllegalStateException("The given key/value pair does not match the cache!");
+      }
+   }
+
+}

--- a/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/Resources.java
+++ b/eap-cluster-app/adminApp/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/Resources.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.infinispan.manager.DefaultCacheManager;
+
+/**
+ * 
+ * Producer for cache manager injection.
+ * 
+ * @author "Wolf-Dieter Fink"
+ */
+public final class Resources {
+
+   @Inject
+   App1CacheManagerProvider cacheManagerProvider;
+   @Inject
+   App2CacheManagerProvider cacheManagerProvider2;
+
+   @Produces
+   DefaultCacheManager getApp1CacheManager() {
+      return cacheManagerProvider.getCacheManager();
+   }
+
+   @Produces
+   @App2Cache
+   DefaultCacheManager getApp2CacheManager() {
+      return cacheManagerProvider2.getCacheManager();
+   }
+
+}

--- a/eap-cluster-app/adminApp/ejb/src/main/resources/META-INF/beans.xml
+++ b/eap-cluster-app/adminApp/ejb/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,23 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Marker file indicating CDI 1.0 should be enabled -->
+
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee 
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/eap-cluster-app/adminApp/ejb/src/main/resources/apponecache-config.xml
+++ b/eap-cluster-app/adminApp/ejb/src/main/resources/apponecache-config.xml
@@ -1,0 +1,16 @@
+<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:infinispan:config:6.0 http://www.infinispan.org/schemas/infinispan-config-6.0.xsd" xmlns="urn:infinispan:config:6.0">
+	<global>
+		<transport clusterName="ClusterOne" distributedSyncTimeout="50000">
+			<properties>
+				<property name="configurationFile" value="jgroups-admin.xml" />
+			  </properties>
+		</transport>
+		<globalJmxStatistics enabled="true"  allowDuplicateDomains="true" cacheManagerName="AdminCacheManager"/>
+	</global>
+	<namedCache name="App1Cache">
+		<clustering mode="replication">
+			<async/>
+			<stateTransfer chunkSize="10000" fetchInMemoryState="true" timeout="240000" />
+		</clustering>
+	</namedCache>
+</infinispan>

--- a/eap-cluster-app/adminApp/ejb/src/main/resources/jgroups-admin.xml
+++ b/eap-cluster-app/adminApp/ejb/src/main/resources/jgroups-admin.xml
@@ -1,0 +1,71 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<config xmlns="urn:org:jgroups"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:org:jgroups file:schema/JGroups-2.8.xsd">
+    <UDP
+            bind_addr="${jgroups.bind_addr:127.0.0.1}"
+            mcast_addr="${jgroups.udp.mcast_addr:228.6.7.10}"
+            mcast_port="${jgroups.udp.mcast_port:46655}"
+            tos="8"
+            ucast_recv_buf_size="20000000"
+            ucast_send_buf_size="640000"
+            mcast_recv_buf_size="25000000"
+            mcast_send_buf_size="640000"
+            loopback="true"
+            discard_incompatible_packets="true"
+            max_bundle_size="64000"
+            max_bundle_timeout="30"
+            ip_ttl="${jgroups.udp.ip_ttl:2}"
+            enable_bundling="true"
+            enable_diagnostics="false"
+
+            thread_naming_pattern="pl"
+
+            thread_pool.enabled="true"
+            thread_pool.min_threads="2"
+            thread_pool.max_threads="30"
+            thread_pool.keep_alive_time="5000"
+            thread_pool.queue_enabled="false"
+            thread_pool.queue_max_size="100"
+            thread_pool.rejection_policy="Discard"
+
+            oob_thread_pool.enabled="true"
+            oob_thread_pool.min_threads="2"
+            oob_thread_pool.max_threads="30"
+            oob_thread_pool.keep_alive_time="5000"
+            oob_thread_pool.queue_enabled="false"
+            oob_thread_pool.queue_max_size="100"
+            oob_thread_pool.rejection_policy="Discard"
+            />
+
+    <PING timeout="3000" num_initial_members="2"/>
+    <MERGE2 max_interval="30000" min_interval="10000"/>
+    <FD_SOCK/>
+    <FD_ALL/>
+    <BARRIER />
+    <pbcast.NAKACK  exponential_backoff="0"
+                    use_mcast_xmit="true"
+                    retransmit_timeout="300,600,1200"
+                    discard_delivered_msgs="true"/>
+    <UNICAST timeout="300,600,1200"/>
+    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000" max_bytes="1000000"/>
+    <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+    <UFC max_credits="500000" min_threshold="0.20"/>
+    <MFC max_credits="500000" min_threshold="0.20"/>
+    <FRAG2 frag_size="60000"  />
+</config>

--- a/eap-cluster-app/adminApp/pom.xml
+++ b/eap-cluster-app/adminApp/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.quickstarts.jdg</groupId>
+        <artifactId>jboss-eap-application</artifactId>
+        <version>6.3.0-redhat-SNAPSHOT</version>
+    </parent>
+    <artifactId>jboss-eap-application-adminApp</artifactId>
+    <packaging>pom</packaging>
+    <name>JBoss JDG Quickstart: jboss-eap-application - adminApp</name>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+    <modules>
+        <module>ear</module>
+        <module>ejb</module>
+    </modules>
+</project>

--- a/eap-cluster-app/appOne/ear/pom.xml
+++ b/eap-cluster-app/appOne/ear/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.quickstarts.jdg</groupId>
+        <artifactId>jboss-eap-application-AppOne</artifactId>
+        <version>6.3.0-redhat-SNAPSHOT</version>
+    </parent>
+    <artifactId>jboss-eap-application-AppOne-ear</artifactId>
+    <packaging>ear</packaging>
+    <name>JBoss JDG Quickstart: jboss-eap-application - AppOne - ear</name>
+    <description>Create the deployable application archive
+     Include the EJB and ISPN application together with the necessary API libraries
+  </description>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+    <dependencies>
+        <!-- add the EJB and WEB project as dependency to include it in the EAR -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-eap-application-AppOne-ejb</artifactId>
+            <type>ejb</type>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-ejb-client-bom</artifactId>
+            <scope>provided</scope>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <!-- define the name for the deployable archive instead of using the default name with the version -->
+        <finalName>${project.parent.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>${ear.plugin.version}</version>
+                <configuration>
+                    <displayName>Application Main</displayName>
+                    <description>A simple quickstart application to demonstrate the
+                        use of JDG inside of an EAP application</description>
+                    <version>6</version>
+                    <generateApplicationXml>true</generateApplicationXml>
+                    <modules>
+                        <ejbModule>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>jboss-eap-application-AppOne-ejb</artifactId>
+                            <bundleFileName>ejb.jar</bundleFileName>
+                        </ejbModule>
+                        <ejbClientModule>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>jboss-eap-application-AppTwo-ejb</artifactId>
+                            <bundleDir>lib</bundleDir>
+                        </ejbClientModule>
+                    </modules>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources/META-INF</directory>
+                <!-- add the classloading configuration -->
+                <includes>
+                    <include>*.xml</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/eap-cluster-app/appOne/ear/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/eap-cluster-app/appOne/ear/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,10 @@
+<jboss-deployment-structure>
+
+    <ear-subdeployments-isolated>true</ear-subdeployments-isolated>
+    <sub-deployment name="ejb.jar">
+        <!-- use the provided JDG modules -->
+        <dependencies>
+            <module name="org.infinispan" slot="jdg-6.3" services="export"/>
+        </dependencies>
+    </sub-deployment>
+</jboss-deployment-structure>

--- a/eap-cluster-app/appOne/ear/src/main/application/META-INF/jboss-ejb-client.xml
+++ b/eap-cluster-app/appOne/ear/src/main/application/META-INF/jboss-ejb-client.xml
@@ -1,0 +1,37 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<jboss-ejb-client xmlns:xsi="urn:jboss:ejb-client:1.2" xsi:noNamespaceSchemaLocation="jboss-ejb-client_1_2.xsd">
+    <client-context>
+        <ejb-receivers>
+            <!-- this is the connection to access the appTwo -->
+            <remoting-ejb-receiver outbound-connection-ref="remote-ejb-connection" />
+        </ejb-receivers>
+        
+        <!-- if an outbound connection connect to a cluster a list of members is provided after successful connection.
+             To connect to this node this cluster element must be defined.
+          -->
+        <clusters>
+          <!-- cluster of remote-ejb-connection -->
+            <cluster name="ejb" security-realm="ejb-security-realm" username="quickuser">
+                <connection-creation-options>
+                    <property name="org.xnio.Options.SSL_ENABLED" value="false" />
+                    <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false" />
+                </connection-creation-options>
+            </cluster>
+        </clusters>
+    </client-context>
+</jboss-ejb-client>

--- a/eap-cluster-app/appOne/ejb/pom.xml
+++ b/eap-cluster-app/appOne/ejb/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.quickstarts.jdg</groupId>
+        <artifactId>jboss-eap-application-AppOne</artifactId>
+        <version>6.3.0-redhat-SNAPSHOT</version>
+    </parent>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <artifactId>jboss-eap-application-AppOne-ejb</artifactId>
+
+    <name>JBoss JDG Quickstart: jboss-eap-application - AppOne - ejb</name>
+    <url>http://maven.apache.org</url>
+    <packaging>ejb</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-ejb-client-bom</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <!-- For JDG caches -->
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.quickstarts.jdg</groupId>
+            <artifactId>jboss-eap-application-AppTwo-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb-client</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>  <!-- must include ejb-plugin to change the EJB version from 2.1 to 3.1 -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ejb-plugin</artifactId>
+                <version>${ejb.plugin.version}</version>
+                <configuration>
+                    <ejbVersion>3.1</ejbVersion>
+                    <generateClient>true</generateClient>
+                    <clientExcludes>
+                        <!-- ensure that the classes for injection are not provided -->
+                        <clientExclude>**/Resources*</clientExclude>
+                        <clientExclude>**/*Provider*</clientExclude>
+                        <clientExclude>**/*Bean*</clientExclude>
+                        <clientExclude>jgroups-udp.xml</clientExclude>
+                        <clientExclude>META-INF/*</clientExclude>
+                    </clientExcludes>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/eap-cluster-app/appOne/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppOneCacheAccess.java
+++ b/eap-cluster-app/appOne/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppOneCacheAccess.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import java.util.Set;
+
+import javax.ejb.Remote;
+
+@Remote
+public interface AppOneCacheAccess {
+
+   void addToLocalCache(String key, String value);
+
+   String getFromLocalCache(String key);
+
+   void verifyApp1Cache(String key, String value);
+
+   Set<String> verifyApp2CacheRemote(String key, String value);
+}

--- a/eap-cluster-app/appOne/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppOneCacheAccessBean.java
+++ b/eap-cluster-app/appOne/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppOneCacheAccessBean.java
@@ -1,0 +1,109 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+import javax.naming.InitialContext;
+
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.jboss.logging.Logger;
+
+/**
+ * <p>
+ * The main bean called by the standalone client.
+ * </p>
+ * <p>
+ * The sub applications, deployed in different servers are called direct or via indirect naming to
+ * hide the lookup name and use a configured name via comp/env environment.
+ * </p>
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+@Stateless
+public class AppOneCacheAccessBean implements AppOneCacheAccess {
+   private static final Logger LOGGER = Logger.getLogger(AppOneCacheAccessBean.class);
+   @Resource
+   SessionContext context;
+
+   @Inject
+   DefaultCacheManager app1CacheManager;
+
+   /**
+    * The context to invoke foreign EJB's as the SessionContext can not be used for that.
+    */
+   private InitialContext iCtx;
+
+   @EJB(lookup = "ejb:jboss-eap-application-AppTwo/ejb/AppTwoCacheAccessBean!org.jboss.as.quickstarts.datagrid.eap.app.AppTwoCacheAccess")
+   AppTwoCacheAccess appTwoProxy;
+
+   /**
+    * Initialize and store the context for the EJB invocations.
+    */
+   @PostConstruct
+   public void init() {
+   }
+
+   @Override
+   public void addToLocalCache(String key, String value) {
+      LOGGER.info("addTo progCache (" + key + "," + value + ")");
+      Cache<String, String> cache = app1CacheManager.getCache("progCache");
+      cache.put(key, value);
+   }
+
+   @Override
+   public String getFromLocalCache(String key) {
+      LOGGER.info("getFrom progCache(" + key + ")");
+      Cache<String, String> cache = app1CacheManager.getCache("progCache");
+      final String value = cache.get(key);
+      LOGGER.info("value=" + value);
+
+      final String nodeName = System.getProperty("jboss.node.name");
+      return "Read progCache for key=" + key + " at server '" + nodeName + "' and get "
+            + (value == null ? "no value" : "value=" + value);
+   }
+
+   @Override
+   public void verifyApp1Cache(String key, String value) {
+      Cache<String, String> cache = app1CacheManager.getCache("App1Cache");
+      final String cacheValue = cache.get(key);
+      if ((value == null && cacheValue != null) || (value != null && !value.equals(cacheValue))) {
+         throw new IllegalStateException("The given key/value pair does not match the cache!");
+      }
+   }
+
+   @Override
+   public Set<String> verifyApp2CacheRemote(String key, String value) {
+      HashSet<String> results = new HashSet<String>();
+
+      for (int i = 0; i < 10; i++) {
+         results.add(this.appTwoProxy.verifyApp2Cache(key, value));
+      }
+      LOGGER.info("Verified 10 times, see " + results.size() + "node(s) " + results);
+
+      return results;
+   }
+}

--- a/eap-cluster-app/appOne/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppOneCacheManagerProvider.java
+++ b/eap-cluster-app/appOne/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppOneCacheManagerProvider.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import java.util.logging.Logger;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+
+/**
+ * Creates a DefaultCacheManager which is configured programmatically.
+ * <b>Infinispan's libraries need to be bundled with the application.</b>
+ * 
+ * @author Wolf-Dieter Fink
+ */
+@ApplicationScoped
+public class AppOneCacheManagerProvider {
+    private static final Logger log = Logger.getLogger(AppOneCacheManagerProvider.class.getName());
+    private DefaultCacheManager manager;
+
+    public DefaultCacheManager getCacheManager() {
+        if (manager == null) {
+            log.info("construct a AppCacheManager");
+
+            GlobalConfiguration glob = new GlobalConfigurationBuilder()
+                    .clusteredDefault() // Builds a default clustered
+                    // notice the file MUST NOT named jgroups-udp.xml as this is provided by the infinispan module and prefered !
+                    .transport().addProperty("configurationFile", "jgroups-app1.xml") // provide a specific JGroups configuration
+                    .clusterName("ClusterOne")
+                    .globalJmxStatistics().allowDuplicateDomains(true).enable() // This method enables the jmx statistics of
+                    // the global configuration and allows for duplicate JMX domains
+                    .build(); // Builds the GlobalConfiguration object
+            Configuration loc = new ConfigurationBuilder().jmxStatistics().enable() // Enable JMX statistics
+                    .clustering().cacheMode(CacheMode.REPL_SYNC) // Set Cache mode to SYNCRONOUS REPLICATED
+                    .build();
+            manager = new DefaultCacheManager(glob, loc, true);
+
+            Configuration progCache = new ConfigurationBuilder().build();
+            manager.defineConfiguration("progCache", progCache);
+            Configuration appCache = new ConfigurationBuilder().clustering().cacheMode(CacheMode.REPL_SYNC).build();
+            manager.defineConfiguration("progCache",appCache);
+        }
+        return manager;
+    }
+
+    @PreDestroy
+    public void cleanUp() {
+        manager.stop();
+        manager = null;
+    }
+
+}

--- a/eap-cluster-app/appOne/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/Resources.java
+++ b/eap-cluster-app/appOne/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/Resources.java
@@ -1,0 +1,18 @@
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.infinispan.manager.DefaultCacheManager;
+
+public class Resources {
+
+    @Inject
+    AppOneCacheManagerProvider cacheManagerProvider;
+
+    @Produces
+    DefaultCacheManager getDefaultCacheManager() {
+        return cacheManagerProvider.getCacheManager();
+    }
+
+}

--- a/eap-cluster-app/appOne/ejb/src/main/resources/META-INF/beans.xml
+++ b/eap-cluster-app/appOne/ejb/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,23 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Marker file indicating CDI 1.0 should be enabled -->
+
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee 
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/eap-cluster-app/appOne/ejb/src/main/resources/jgroups-app1.xml
+++ b/eap-cluster-app/appOne/ejb/src/main/resources/jgroups-app1.xml
@@ -1,0 +1,71 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<config xmlns="urn:org:jgroups"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:org:jgroups file:schema/JGroups-2.8.xsd">
+    <UDP
+            bind_addr="${jgroups.bind_addr:127.0.0.1}"
+            mcast_addr="${jgroups.udp.mcast_addr:228.6.7.10}"
+            mcast_port="${jgroups.udp.mcast_port:46655}"
+            tos="8"
+            ucast_recv_buf_size="20000000"
+            ucast_send_buf_size="640000"
+            mcast_recv_buf_size="25000000"
+            mcast_send_buf_size="640000"
+            loopback="true"
+            discard_incompatible_packets="true"
+            max_bundle_size="64000"
+            max_bundle_timeout="30"
+            ip_ttl="${jgroups.udp.ip_ttl:2}"
+            enable_bundling="true"
+            enable_diagnostics="false"
+
+            thread_naming_pattern="pl"
+
+            thread_pool.enabled="true"
+            thread_pool.min_threads="2"
+            thread_pool.max_threads="30"
+            thread_pool.keep_alive_time="5000"
+            thread_pool.queue_enabled="false"
+            thread_pool.queue_max_size="100"
+            thread_pool.rejection_policy="Discard"
+
+            oob_thread_pool.enabled="true"
+            oob_thread_pool.min_threads="2"
+            oob_thread_pool.max_threads="30"
+            oob_thread_pool.keep_alive_time="5000"
+            oob_thread_pool.queue_enabled="false"
+            oob_thread_pool.queue_max_size="100"
+            oob_thread_pool.rejection_policy="Discard"
+            />
+
+    <PING timeout="3000" num_initial_members="2"/>
+    <MERGE2 max_interval="30000" min_interval="10000"/>
+    <FD_SOCK/>
+    <FD_ALL/>
+    <BARRIER />
+    <pbcast.NAKACK  exponential_backoff="0"
+                    use_mcast_xmit="true"
+                    retransmit_timeout="300,600,1200"
+                    discard_delivered_msgs="true"/>
+    <UNICAST timeout="300,600,1200"/>
+    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000" max_bytes="1000000"/>
+    <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+    <UFC max_credits="500000" min_threshold="0.20"/>
+    <MFC max_credits="500000" min_threshold="0.20"/>
+    <FRAG2 frag_size="60000"  />
+</config>

--- a/eap-cluster-app/appOne/pom.xml
+++ b/eap-cluster-app/appOne/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.quickstarts.jdg</groupId>
+        <artifactId>jboss-eap-application</artifactId>
+        <version>6.3.0-redhat-SNAPSHOT</version>
+    </parent>
+    <artifactId>jboss-eap-application-AppOne</artifactId>
+    <packaging>pom</packaging>
+    <name>JBoss JDG Quickstart: jboss-eap-application - AppOne</name>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+    <modules>
+        <module>ear</module>
+        <module>ejb</module>
+    </modules>
+</project>

--- a/eap-cluster-app/appTwo/ear/pom.xml
+++ b/eap-cluster-app/appTwo/ear/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.quickstarts.jdg</groupId>
+        <artifactId>jboss-eap-application-AppTwo</artifactId>
+        <version>6.3.0-redhat-SNAPSHOT</version>
+    </parent>
+    <artifactId>jboss-eap-application-AppTwo-ear</artifactId>
+    <packaging>ear</packaging>
+    <name>JBoss JDG Quickstart: jboss-eap-application - AppTwo - ear</name>
+    <description>Create the deployable application archive
+     Include the EJB and ISPN application together with the necessary API libraries
+  </description>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+    <dependencies>
+        <!-- add the EJB and WEB project as dependency to include it in the EAR -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-eap-application-AppTwo-ejb</artifactId>
+            <type>ejb</type>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-ejb-client-bom</artifactId>
+            <scope>provided</scope>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <!-- define the name for the deployable archive instead of using the default name with the version -->
+        <finalName>${project.parent.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>${ear.plugin.version}</version>
+                <configuration>
+                    <displayName>Application Main</displayName>
+                    <description>A simple quickstart application to demonstrate the
+                        use of JDG inside of an EAP application</description>
+                    <version>6</version>
+                    <generateApplicationXml>true</generateApplicationXml>
+                    <modules>
+                        <ejbModule>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>jboss-eap-application-AppTwo-ejb</artifactId>
+                            <bundleFileName>ejb.jar</bundleFileName>
+                        </ejbModule>
+                    </modules>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources/META-INF</directory>
+                <!-- add the classloading configuration -->
+                <includes>
+                    <include>*.xml</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/eap-cluster-app/appTwo/ear/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/eap-cluster-app/appTwo/ear/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,11 @@
+<jboss-deployment-structure>
+
+    <ear-subdeployments-isolated>true</ear-subdeployments-isolated>
+    <sub-deployment name="ejb.jar">
+        <!-- use the provided JDG modules -->
+        <dependencies>
+            <module name="org.infinispan" slot="jdg-6.3" services="export"/>
+        </dependencies>
+    </sub-deployment>
+
+</jboss-deployment-structure>

--- a/eap-cluster-app/appTwo/ejb/pom.xml
+++ b/eap-cluster-app/appTwo/ejb/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.quickstarts.jdg</groupId>
+        <artifactId>jboss-eap-application-AppTwo</artifactId>
+        <version>6.3.0-redhat-SNAPSHOT</version>
+    </parent>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <artifactId>jboss-eap-application-AppTwo-ejb</artifactId>
+
+    <name>JBoss JDG Quickstart: jboss-eap-application - AppTwo - ejb</name>
+    <url>http://maven.apache.org</url>
+    <packaging>ejb</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-ejb-client-bom</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <!-- For JDG caches -->
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>  <!-- must include ejb-plugin to change the EJB version from 2.1 to 3.1 -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ejb-plugin</artifactId>
+                <version>${ejb.plugin.version}</version>
+                <configuration>
+                    <ejbVersion>3.1</ejbVersion>
+                    <generateClient>true</generateClient>
+                    <clientExcludes>
+                        <!-- ensure that the classes for injection are not provided -->
+                        <clientExclude>**/*Resources*</clientExclude>
+                        <clientExclude>**/*Provider*</clientExclude>
+                        <clientExclude>**/*Bean*</clientExclude>
+                        <clientExclude>jgroups-udp.xml</clientExclude>
+                        <clientExclude>META-INF/*</clientExclude>
+                    </clientExcludes>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/eap-cluster-app/appTwo/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppTwoCacheAccess.java
+++ b/eap-cluster-app/appTwo/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppTwoCacheAccess.java
@@ -1,0 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import javax.ejb.Remote;
+
+@Remote
+public interface AppTwoCacheAccess {
+   String verifyApp2Cache(String key, String value);
+}

--- a/eap-cluster-app/appTwo/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppTwoCacheAccessBean.java
+++ b/eap-cluster-app/appTwo/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppTwoCacheAccessBean.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.jboss.logging.Logger;
+
+/**
+ * <p>
+ * The main bean called by the standalone client.
+ * </p>
+ * <p>
+ * The sub applications, deployed in different servers are called direct or via indirect naming to
+ * hide the lookup name and use a configured name via comp/env environment.
+ * </p>
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+@Stateless
+public class AppTwoCacheAccessBean implements AppTwoCacheAccess {
+   private static final Logger LOGGER = Logger.getLogger(AppTwoCacheAccessBean.class);
+
+   @Inject
+   DefaultCacheManager appCacheManager;
+
+   @Override
+   public String verifyApp2Cache(String key, String value) {
+      Cache<String, String> cache = appCacheManager.getCache("App2Cache");
+      final String cacheValue = cache.get(key);
+      if ((value == null && cacheValue != null) || (value != null && !value.equals(cacheValue))) {
+         throw new IllegalStateException("The given key/value pair does not match the cache!");
+      }
+      return System.getProperty("jboss.node.name");
+   }
+}

--- a/eap-cluster-app/appTwo/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppTwoCacheManagerProvider.java
+++ b/eap-cluster-app/appTwo/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppTwoCacheManagerProvider.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import java.util.logging.Logger;
+
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.transaction.lookup.GenericTransactionManagerLookup;
+
+/**
+ * Creates a DefaultCacheManager which is configured programmatically. <b>Infinispan's libraries
+ * need to be bundled with the application.</b>
+ * 
+ * @author Wolf-Dieter Fink
+ */
+@ApplicationScoped
+public class AppTwoCacheManagerProvider {
+   private static final Logger log = Logger.getLogger(AppTwoCacheManagerProvider.class.getName());
+   private DefaultCacheManager manager;
+
+   public DefaultCacheManager getCacheManager() {
+      if (manager == null) {
+         log.info("construct a AppTwoCacheManager");
+
+         GlobalConfiguration glob = new GlobalConfigurationBuilder().clusteredDefault() // Builds a default clustered
+               // notice the file MUST NOT named jgroups-udp.xml as this is provided by the infinispan module and prefered !
+               .transport().addProperty("configurationFile", "jgroups-app2.xml") // provide a specific JGroups configuration
+               .clusterName("ClusterTwo").globalJmxStatistics().allowDuplicateDomains(true).enable() // This method enables the jmx statistics of
+               // the global configuration and allows for duplicate JMX domains
+               .build(); // Builds the GlobalConfiguration object
+         Configuration loc = new ConfigurationBuilder().jmxStatistics().enable() // Enable JMX statistics
+               .clustering().cacheMode(CacheMode.DIST_SYNC) // Set Cache mode to SYNC DISTRIBUTED
+               .build();
+         manager = new DefaultCacheManager(glob, loc, true);
+
+         Configuration cache = new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_SYNC)
+               .transaction().transactionMode(TransactionMode.TRANSACTIONAL)
+               .transactionManagerLookup(new GenericTransactionManagerLookup()).build();
+         manager.defineConfiguration("App2Cache", cache);
+      }
+      return manager;
+   }
+
+   @PreDestroy
+   public void cleanUp() {
+      manager.stop();
+      manager = null;
+   }
+
+}

--- a/eap-cluster-app/appTwo/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/Resources.java
+++ b/eap-cluster-app/appTwo/ejb/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/Resources.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.infinispan.manager.DefaultCacheManager;
+
+/**
+ * 
+ * Producer for cache manager injection.
+ * 
+ * @author "Wolf-Dieter Fink"
+ */
+public final class Resources {
+
+    @Inject
+    AppTwoCacheManagerProvider cacheManagerProvider;
+
+    @Produces
+    DefaultCacheManager getDefaultCacheManager() {
+        return cacheManagerProvider.getCacheManager();
+    }
+
+}

--- a/eap-cluster-app/appTwo/ejb/src/main/resources/META-INF/beans.xml
+++ b/eap-cluster-app/appTwo/ejb/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,23 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Marker file indicating CDI 1.0 should be enabled -->
+
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee 
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/eap-cluster-app/appTwo/ejb/src/main/resources/META-INF/jboss-ejb3.xml
+++ b/eap-cluster-app/appTwo/ejb/src/main/resources/META-INF/jboss-ejb3.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee" xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:s="urn:security" xmlns:c="urn:clustering:1.0"
+    xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd
+                     http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
+    version="3.1" impl-version="2.0">
+    <enterprise-beans>
+    </enterprise-beans>
+    <assembly-descriptor>
+      <!-- mark all EJB's of the application as clustered (without using the jboss specific @Clustered annotation for each class) -->
+        <c:clustering>
+            <ejb-name>*</ejb-name>
+            <c:clustered>true</c:clustered>
+        </c:clustering>
+    </assembly-descriptor>
+</jboss:ejb-jar>

--- a/eap-cluster-app/appTwo/ejb/src/main/resources/jgroups-app2.xml
+++ b/eap-cluster-app/appTwo/ejb/src/main/resources/jgroups-app2.xml
@@ -1,0 +1,71 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<config xmlns="urn:org:jgroups"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:org:jgroups file:schema/JGroups-2.8.xsd">
+    <UDP
+            bind_addr="${jgroups.bind_addr:127.0.0.1}"
+            mcast_addr="${jgroups.udp.mcast_addr:228.6.7.10}"
+            mcast_port="${jgroups.udp.mcast_port:46655}"
+            tos="8"
+            ucast_recv_buf_size="20000000"
+            ucast_send_buf_size="640000"
+            mcast_recv_buf_size="25000000"
+            mcast_send_buf_size="640000"
+            loopback="true"
+            discard_incompatible_packets="true"
+            max_bundle_size="64000"
+            max_bundle_timeout="30"
+            ip_ttl="${jgroups.udp.ip_ttl:2}"
+            enable_bundling="true"
+            enable_diagnostics="false"
+
+            thread_naming_pattern="pl"
+
+            thread_pool.enabled="true"
+            thread_pool.min_threads="2"
+            thread_pool.max_threads="30"
+            thread_pool.keep_alive_time="5000"
+            thread_pool.queue_enabled="false"
+            thread_pool.queue_max_size="100"
+            thread_pool.rejection_policy="Discard"
+
+            oob_thread_pool.enabled="true"
+            oob_thread_pool.min_threads="2"
+            oob_thread_pool.max_threads="30"
+            oob_thread_pool.keep_alive_time="5000"
+            oob_thread_pool.queue_enabled="false"
+            oob_thread_pool.queue_max_size="100"
+            oob_thread_pool.rejection_policy="Discard"
+            />
+
+    <PING timeout="3000" num_initial_members="2"/>
+    <MERGE2 max_interval="30000" min_interval="10000"/>
+    <FD_SOCK/>
+    <FD_ALL/>
+    <BARRIER />
+    <pbcast.NAKACK  exponential_backoff="0"
+                    use_mcast_xmit="true"
+                    retransmit_timeout="300,600,1200"
+                    discard_delivered_msgs="true"/>
+    <UNICAST timeout="300,600,1200"/>
+    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000" max_bytes="1000000"/>
+    <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+    <UFC max_credits="500000" min_threshold="0.20"/>
+    <MFC max_credits="500000" min_threshold="0.20"/>
+    <FRAG2 frag_size="60000"  />
+</config>

--- a/eap-cluster-app/appTwo/pom.xml
+++ b/eap-cluster-app/appTwo/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.quickstarts.jdg</groupId>
+        <artifactId>jboss-eap-application</artifactId>
+        <version>6.3.0-redhat-SNAPSHOT</version>
+    </parent>
+    <artifactId>jboss-eap-application-AppTwo</artifactId>
+    <packaging>pom</packaging>
+    <name>JBoss JDG Quickstart: jboss-eap-application - AppTwo</name>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+    <modules>
+        <module>ear</module>
+        <module>ejb</module>
+    </modules>
+</project>

--- a/eap-cluster-app/client/pom.xml
+++ b/eap-cluster-app/client/pom.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jboss-eap-application-client</artifactId>
+
+    <name>JBoss JDG Quickstart: jboss-eap-application - client</name>
+    <packaging>jar</packaging>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <parent>
+        <groupId>org.jboss.quickstarts.jdg</groupId>
+        <artifactId>jboss-eap-application</artifactId>
+        <version>6.3.0-redhat-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-eap-application-AppOne-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb-client</type>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-eap-application-adminApp-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb-client</type>
+        </dependency>
+
+    <!-- Import the transaction spec API, we use runtime scope because we aren't 
+      using any direct reference to the spec API in our client code -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+    <!-- client communications with the server use XNIO -->
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-nio</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+    <!-- The client needs JBoss remoting to access the server -->
+        <dependency>
+            <groupId>org.jboss.remoting3</groupId>
+            <artifactId>jboss-remoting</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+    <!-- Remote EJB accesses can be secured -->
+        <dependency>
+            <groupId>org.jboss.sasl</groupId>
+            <artifactId>jboss-sasl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+
+    <!-- data serialization for invoking remote EJBs -->
+        <dependency>
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling-river</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+    <!-- Import the EJB 3.1 API, we use runtime scope because we aren't using 
+      any direct reference to EJB spec API in our client code -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-ejb-client</artifactId>
+            <!--  version>${version.jboss.ejb.client}</version -->
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+      <!-- Add the maven exec plugin to allow us to run a java program via maven -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+     </build>
+</project>
+

--- a/eap-cluster-app/client/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AdminClient.java
+++ b/eap-cluster-app/client/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AdminClient.java
@@ -1,0 +1,133 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
+
+/**
+ * <p>
+ * A simple standalone application which uses the JBoss API to invoke the MainApp demonstration
+ * Bean.
+ * </p>
+ * <p>
+ * With the boolean property <i>UseScopedContext</i> the basic example or the example with the
+ * scoped-environment will be called.
+ * </p>
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+public class AdminClient {
+
+   /**
+    * @param args
+    *           optional to override the connect parameter
+    *           <ul>
+    *           <li>hostname for AdminApp (default localhost)</li>
+    *           <li>port for AdminApp (default 4447)</li>
+    *           <li>hostname for AppOne (default localhost)</li>
+    *           <li>port for AppOne (default 4547)</li>
+    *           </ul>
+    * @throws Exception
+    */
+   public static void main(String[] args) throws Exception {
+      String hostAdmin = "localhost";
+      String portAdmin = "4447";
+      String hostAppOne = "localhost";
+      String portAppOne = "4547";
+      
+      // suppress output of client messages
+      Logger.getLogger("org.jboss").setLevel(Level.OFF);
+      Logger.getLogger("org.xnio").setLevel(Level.OFF);
+
+      if(args.length > 0) {
+         hostAdmin = args[0];
+      }
+      if(args.length > 1) {
+         portAdmin = args[1];
+      }
+      if(args.length > 2) {
+         hostAppOne = args[2];
+      }
+      if(args.length > 3) {
+         portAppOne = args[3];
+      }
+      
+      Properties p = new Properties();
+      p.put("remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED", "false");
+      p.put("remote.connections", "admin,appOne");
+      p.put("remote.connection.admin.port", portAdmin);
+      p.put("remote.connection.admin.host", hostAdmin);
+      p.put("remote.connection.admin.username", "quickuser");
+      p.put("remote.connection.admin.password", "quick-123");
+      p.put("remote.connection.appOne.port", portAppOne);
+      p.put("remote.connection.appOne.host", hostAppOne);
+      p.put("remote.connection.appOne.username", "quickuser");
+      p.put("remote.connection.appOne.password", "quick-123");
+
+      EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(p);
+      ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
+      EJBClientContext.setSelector(selector);
+
+      Properties props = new Properties();
+      props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+      InitialContext context = new InitialContext(props);
+
+      final String adminLookup = "ejb:jboss-eap-application-adminApp/ejb//CacheAdminBean!" + CacheAdmin.class.getName();
+      final CacheAdmin admin = (CacheAdmin) context.lookup(adminLookup);
+
+      System.out.println("        Add a value to App1Cache with the AdminApp and check on the same instance that the value is correct added");
+      admin.addToApp1Cache("App1One", "The App1 One entry");
+      // check that the Admin has the correct key entry local
+      admin.verifyApp1Cache("App1One", "The App1 One entry");
+      System.out.println("          success");
+
+      final String appOneLookup = "ejb:jboss-eap-application-AppOne/ejb//AppOneCacheAccessBean!"
+            + AppOneCacheAccess.class.getName();
+      final AppOneCacheAccess appOne = (AppOneCacheAccess) context.lookup(appOneLookup);
+      
+      System.out.println("        Check the previous added value of App1Cache by accessing the AppOne Server");
+      // check that the App1 cache has the correct replicated key entry
+      appOne.verifyApp1Cache("App1One", "The App1 One entry");
+      System.out.println("          success");
+
+      System.out.println("        Add a value to App2Cache and check on the same instance that the value is correct added");
+      admin.addToApp2Cache("One", "The App2 One entry");
+      admin.verifyApp2Cache("One", "The App2 One entry");
+      System.out.println("          success");
+
+      // check that the cache is transactional
+      System.out.println("        Check whether changes to a cache are rollbacked if the transaction fail");
+      admin.removeFromApp2Cache("SouldNeverExist");
+      admin.addToApp2Cache("SouldNeverExist", "This value should not available as the transaction fail", true);
+      if (admin.containsApp2Key("SouldNeverExist")) {
+         throw new RuntimeException("Unexpected result, the key exists after transaction rollback!");
+      } else {
+         System.out.println("        The cache App2 work as expected on rollback");
+      }
+   }
+}

--- a/eap-cluster-app/client/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppOneClient.java
+++ b/eap-cluster-app/client/src/main/java/org/jboss/as/quickstarts/datagrid/eap/app/AppOneClient.java
@@ -1,0 +1,115 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.datagrid.eap.app;
+
+import java.util.Properties;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
+
+/**
+ * <p>
+ * A simple standalone application which uses the JBoss API to invoke the AppOne demonstration Bean.
+ * </p>
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+public class AppOneClient {
+
+   /**
+    * @param args
+    *           optional to override the connect parameter
+    *           <ul>
+    *           <li>hostname for AdminApp (default localhost)</li>
+    *           <li>port for AdminApp (default 4447)</li>
+    *           <li>hostname for AppOne (default localhost)</li>
+    *           <li>port for AppOne (default 4547)</li>
+    *           </ul>
+    * @throws Exception
+    */
+   public static void main(String[] args) throws Exception {
+      String hostAdmin = "localhost";
+      String portAdmin = "4447";
+      String hostAppOne = "localhost";
+      String portAppOne = "4547";
+
+      // suppress output of client messages
+      Logger.getLogger("org.jboss").setLevel(Level.OFF);
+      Logger.getLogger("org.xnio").setLevel(Level.OFF);
+
+      if (args.length > 0) {
+         hostAdmin = args[0];
+      }
+      if (args.length > 1) {
+         portAdmin = args[1];
+      }
+      if (args.length > 2) {
+         hostAppOne = args[2];
+      }
+      if (args.length > 3) {
+         portAppOne = args[3];
+      }
+
+      Properties p = new Properties();
+      p.put("remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED", "false");
+      p.put("remote.connections", "admin,appOne");
+      p.put("remote.connection.admin.port", portAdmin);
+      p.put("remote.connection.admin.host", hostAdmin);
+      p.put("remote.connection.admin.username", "quickuser");
+      p.put("remote.connection.admin.password", "quick-123");
+      p.put("remote.connection.appOne.port", portAppOne);
+      p.put("remote.connection.appOne.host", hostAppOne);
+      p.put("remote.connection.appOne.username", "quickuser");
+      p.put("remote.connection.appOne.password", "quick-123");
+
+      EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(p);
+      ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
+      EJBClientContext.setSelector(selector);
+
+      Properties props = new Properties();
+      props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+      InitialContext context = new InitialContext(props);
+
+      System.out.println("        Add a value to App2Cache with the AdminApp");
+
+      final String adminLookup = "ejb:jboss-eap-application-adminApp/ejb//CacheAdminBean!" + CacheAdmin.class.getName();
+      final CacheAdmin admin = (CacheAdmin) context.lookup(adminLookup);
+      admin.addToApp2Cache("App2Entry", "The App2 entry");
+      // check that the Admin has the correct key entry local
+      admin.verifyApp2Cache("App2Entry", "The App2 entry");
+
+      final String appOneLookup = "ejb:jboss-eap-application-AppOne/ejb//AppOneCacheAccessBean!"
+            + AppOneCacheAccess.class.getName();
+      final AppOneCacheAccess appOne = (AppOneCacheAccess) context.lookup(appOneLookup);
+
+      System.out.println("        Access the App2Cache from the AppOneServer by using the clustered EJB@AppTwoServer");
+      // run AppOne remote access to AppTwo and provide the cluster nodes 
+      Set<String> app2nodes = appOne.verifyApp2CacheRemote("App2Entry", "The App2 entry");
+
+      System.out.println("          success : received the following node names for EJB invocation : " + app2nodes);
+   }
+
+}

--- a/eap-cluster-app/deploy-domain.cli
+++ b/eap-cluster-app/deploy-domain.cli
@@ -1,0 +1,5 @@
+batch
+deploy adminApp/ear/target/jboss-eap-application-adminApp.ear --server-groups=quickstart-eap-admin
+deploy appOne/ear/target/jboss-eap-application-AppOne.ear --server-groups=quickstart-eap-appone
+deploy appTwo/ear/target/jboss-eap-application-AppTwo.ear --server-groups=quickstart-eap-apptwo
+run-batch

--- a/eap-cluster-app/install-appOne-standalone.cli
+++ b/eap-cluster-app/install-appOne-standalone.cli
@@ -1,0 +1,13 @@
+batch
+# Configure the connection from main server to "one" and "two"
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=remote-ejb:add(host=localhost, port=4647)
+
+# add security realm
+/core-service=management/security-realm=ejb-security-realm:add()
+/core-service=management/security-realm=ejb-security-realm/server-identity=secret:add(value=cXVpY2stMTIz)
+
+# add the outbound connections to the remoting subsystem
+/subsystem=remoting/remote-outbound-connection=remote-ejb-connection:add(outbound-socket-binding-ref=remote-ejb, security-realm=ejb-security-realm, username=quickuser)
+/subsystem=remoting/remote-outbound-connection=remote-ejb-connection/property=SASL_POLICY_NOANONYMOUS:add(value=false)
+/subsystem=remoting/remote-outbound-connection=remote-ejb-connection/property=SSL_ENABLED:add(value=false)
+run-batch

--- a/eap-cluster-app/install-domain.cli
+++ b/eap-cluster-app/install-domain.cli
@@ -1,0 +1,73 @@
+# stop the preconfigured server for the domain
+batch
+# first stop the default servers, block until the server is down
+/host=master/server-config=server-one:stop(blocking=true)
+/host=master/server-config=server-two:stop(blocking=true)
+
+# remove the default server configuration and server-groups
+/host=master/server-config=server-one:remove
+/host=master/server-config=server-two:remove
+/host=master/server-config=server-three:remove
+/server-group=main-server-group:remove
+/server-group=other-server-group:remove
+
+
+# ----  configure the domain for the JDG quickstart ieap-cluster-app
+
+# disable the local authentication for applications
+#/host=master/core-service=management/security-realm=ApplicationRealm/authentication=local:remove
+
+# Configure the connection from AppOne server to AppTwo server
+#
+
+# add the security realms with the secret (password base64) values for the server communication
+/host=master/core-service=management/security-realm=ejb-security-realm:add()
+/host=master/core-service=management/security-realm=ejb-security-realm/server-identity=secret:add(value=cXVpY2stMTIz)
+
+# add the socket binding to the full-sockets, used by the AppOne server
+/socket-binding-group=full-sockets/remote-destination-outbound-socket-binding=remote-ejb:add(host=localhost, port=4647)
+
+# add the outbound connections to the remoting subsystem of the full-profile used by AppOne server
+/profile=full/subsystem=remoting/remote-outbound-connection=remote-ejb-connection:add(outbound-socket-binding-ref=remote-ejb, security-realm=ejb-security-realm, username=quickuser)
+/profile=full/subsystem=remoting/remote-outbound-connection=remote-ejb-connection/property=SASL_POLICY_NOANONYMOUS:add(value=false)
+/profile=full/subsystem=remoting/remote-outbound-connection=remote-ejb-connection/property=SSL_ENABLED:add(value=false)
+
+
+
+
+# adjust the default JVM configuration to minimum
+/host=master/jvm=default:write-attribute(name=permgen-size, value=64m)
+/host=master/jvm=default:write-attribute(name=max-permgen-size, value=128m)
+
+#add the group and the server which handle the AdminApp
+/server-group=quickstart-eap-admin:add(profile=full,socket-binding-group=full-sockets)
+/server-group=quickstart-eap-admin/jvm=default:add()
+/host=master/server-config=AppAdminServer:add(auto-start=true, group=quickstart-eap-admin)
+
+#add the group and the servers for the AppOne
+# AppOne is not a clustered application, so use full profile
+
+# remove the not wanted messaging subsystem
+/profile=full/subsystem=messaging:remove
+
+/server-group=quickstart-eap-appone:add(profile=full,socket-binding-group=full-sockets)
+/server-group=quickstart-eap-appone/jvm=default:add()
+/host=master/server-config=AppOneServer:add(auto-start=true, group=quickstart-eap-appone, socket-binding-port-offset=100)
+
+#add the group and the servers for the AppTwo
+# AppTwo will be a clustered application, so use HA and add two servers
+/server-group=quickstart-eap-apptwo:add(profile=ha,socket-binding-group=ha-sockets)
+/server-group=quickstart-eap-apptwo/jvm=default:add()
+/host=master/server-config=AppTwoServer1:add(auto-start=true, group=quickstart-eap-apptwo, socket-binding-port-offset=200)
+/host=master/server-config=AppTwoServer2:add(auto-start=true, group=quickstart-eap-apptwo, socket-binding-port-offset=300)
+
+run-batch
+
+# without restart, outside the batch, there are different problems
+:restart-servers
+
+# finally start the configured servers
+/host=master/server-config=AppAdminServer:start
+/host=master/server-config=AppOneServer:start
+/host=master/server-config=AppTwoServer1:start
+/host=master/server-config=AppTwoServer2:start

--- a/eap-cluster-app/pom.xml
+++ b/eap-cluster-app/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.quickstarts.jdg</groupId>
+    <artifactId>jboss-eap-application</artifactId>
+    <version>6.3.0-redhat-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>JBoss JDG Quickstart: jboss-eap-application - parent</name>
+    <description>eap cluster application: An example that demonstrates how to use a JDG cache inside of an EAP application.
+     This POM defines common properties to specify the used versions and plugins.
+     The subprojects are built in the appropriate sequence. 
+  </description>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+    <modules>
+        <module>appOne</module>
+        <module>appTwo</module>
+        <module>adminApp</module>
+        <module>client</module>
+    </modules>
+    <properties>
+    <!-- Explicitly declaring the source encoding eliminates the following 
+      message: -->
+    <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
+      resources, i.e. build is platform dependent! -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <version.jboss.as>7.2.1.Final-redhat-10</version.jboss.as>
+
+        <version.jboss.spec.javaee.6.0>3.0.2.Final-redhat-4</version.jboss.spec.javaee.6.0>
+
+        <version.org.infinispan>6.0.3.Final-redhat-3</version.org.infinispan>
+
+        <!-- other versions -->
+        <version.jboss.ejb.client>1.0.23.Final-redhat-1</version.jboss.ejb.client>
+        
+        <!-- other plugin versions -->
+
+        <!-- maven-compiler-plugin -->
+        <compiler.plugin.version>3.1</compiler.plugin.version>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
+
+        <exec.plugin.version>1.2.1</exec.plugin.version>
+        <dependency.plugin.version>2.1</dependency.plugin.version>
+        <ejb.plugin.version>2.3</ejb.plugin.version>
+        <ear.plugin.version>2.6</ear.plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-bom</artifactId>
+                <version>${version.org.infinispan}</version>
+                <type>pom</type>
+            </dependency>
+            <!-- Define the version of JBoss' Java EE 6 APIs we want to import. Any 
+              dependencies from org.jboss.spec will have their version defined by this 
+              BOM -->
+            <!-- JBoss distributes a complete set of Java EE 6 APIs including a Bill 
+              of Materials (BOM). A BOM specifies the versions of a "stack" (or a collection) 
+              of artifacts. We use this here so that we always get the correct versions 
+              of artifacts. Here we use the jboss-javaee-6.0 stack (you can read this as 
+              the JBoss stack of the Java EE 6 APIs). You can actually use this stack with 
+              any version of JBoss EAP that implements Java EE 6. -->
+            <dependency>
+                <groupId>org.jboss.spec</groupId>
+                <artifactId>jboss-javaee-6.0</artifactId>
+                <version>${version.jboss.spec.javaee.6.0}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-ejb-client-bom</artifactId>
+                <version>${version.jboss.as}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec.plugin.version}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/eap-cluster-app/undeploy-domain.cli
+++ b/eap-cluster-app/undeploy-domain.cli
@@ -1,0 +1,3 @@
+undeploy jboss-eap-application-adminApp.ear --all-relevant-server-groups
+undeploy jboss-eap-application-AppOne.ear --all-relevant-server-groups
+undeploy jboss-eap-application-AppTwo.ear --all-relevant-server-groups

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>remote-query</module>
         <module>rest-endpoint</module>
         <module>secure-embedded-cache</module>
+        <module>eap-cluster-app</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
The provided JDG modules for the EAP server are used.
