### PR TITLE
Updated subsystem versions in README files for ISPN 7

### DIFF
--- a/hotrod-endpoint/README.md
+++ b/hotrod-endpoint/README.md
@@ -42,7 +42,7 @@ Configure JDG
 * Datasource subsystem definition:
 
     
-        <subsystem xmlns="urn:jboss:domain:datasources:1.1">
+        <subsystem xmlns="urn:jboss:domain:datasources:2.0">
             <!-- Define this Datasource with jndi name  java:jboss/datasources/ExampleDS -->
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -67,7 +67,7 @@ Configure JDG
 
 * Infinispan subsystem definition:
 
-        <subsystem xmlns="urn:infinispan:server:core:6.1" default-cache-container="local">
+        <subsystem xmlns="urn:infinispan:server:core:7.0" default-cache-container="local">
             <cache-container name="local" default-cache="default">
                 <local-cache name="default" start="EAGER">
                     <locking acquire-timeout="30000" concurrency-level="1000" striping="false"/>

--- a/hotrod-secured/README.md
+++ b/hotrod-secured/README.md
@@ -63,7 +63,7 @@ Configure JDG
 * Enpoint subsystem definition:
   The following configuration enables authentication against ApplicationRealm, using the DIGEST-MD5 SASL mechanism: 
 
-        <subsystem xmlns="urn:infinispan:server:endpoint:6.1">
+        <subsystem xmlns="urn:infinispan:server:endpoint:7.0">
             <hotrod-connector socket-binding="hotrod" cache-container="local">
                 <topology-state-transfer lazy-retrieval="false" lock-timeout="1000" replication-timeout="5000"/>
                 <authentication security-realm="ApplicationRealm">
@@ -83,7 +83,7 @@ Configure JDG
 * Infinispan subsystem definition:
   Server supports authorization with cache configuration defined below
 
-        <subsystem xmlns="urn:infinispan:server:core:6.1">
+        <subsystem xmlns="urn:infinispan:server:core:7.0">
             <cache-container name="local" default-cache="teams">
                 <security>
                     <authorization>
@@ -113,8 +113,8 @@ Start JDG
 Add new users to ApplicationRealm
 ---------------------------------
 
-        <JDG_HOME>/bin/add-user.sh -a -u 'coach'      -p 'qwerty110!' -ro coach
-        <JDG_HOME>/bin/add-user.sh -a -u 'player'     -p 'qwerty111!' -ro player
+        <JDG_HOME>/bin/add-user.sh -a -u 'coach'      -p 'coachPass9!' -ro coach
+        <JDG_HOME>/bin/add-user.sh -a -u 'player'     -p 'playerPass9!' -ro player
 
 Hot Rod client configuration
 ----------------------------

--- a/memcached-endpoint/README.md
+++ b/memcached-endpoint/README.md
@@ -42,7 +42,7 @@ Configure JDG
 * Datasource subsystem definition:
 
     
-        <subsystem xmlns="urn:jboss:domain:datasources:1.1">
+        <subsystem xmlns="urn:jboss:domain:datasources:2.0">
             <!-- Define this Datasource with jndi name  java:jboss/datasources/ExampleDS -->
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -67,7 +67,7 @@ Configure JDG
 
 * Infinispan subsystem definition:
 
-        <subsystem xmlns="urn:infinispan:server:core:6.1" default-cache-container="local">
+        <subsystem xmlns="urn:infinispan:server:core:7.0" default-cache-container="local">
             <cache-container name="local" default-cache="default">
                 <local-cache name="default" start="EAGER">
                     <locking acquire-timeout="30000" concurrency-level="1000" striping="false"/>

--- a/rest-endpoint/README.md
+++ b/rest-endpoint/README.md
@@ -42,7 +42,7 @@ Configure JDG
 * Datasource subsystem definition:
 
     
-        <subsystem xmlns="urn:jboss:domain:datasources:1.1">
+        <subsystem xmlns="urn:jboss:domain:datasources:2.0">
             <!-- Define this Datasource with jndi name  java:jboss/datasources/ExampleDS -->
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -67,7 +67,7 @@ Configure JDG
 
 * Infinispan subsystem definition:
 
-        <subsystem xmlns="urn:infinispan:server:core:6.1" default-cache-container="local">
+        <subsystem xmlns="urn:infinispan:server:core:7.0" default-cache-container="local">
             <cache-container name="local" default-cache="default">
                 <local-cache name="default" start="EAGER">
                     <locking acquire-timeout="30000" concurrency-level="1000" striping="false"/>


### PR DESCRIPTION
Comment: the password change in hotrod-secured is because EAP 6.3 didn't consider the old ones as strong enough and refused them.