### PR TITLE
BZ1184471 remote-query quickstart throwing java.lang.ClassCastException

### DIFF
--- a/remote-query/src/main/java/org/jboss/as/quickstarts/datagrid/hotrod/query/AddressBookManager.java
+++ b/remote-query/src/main/java/org/jboss/as/quickstarts/datagrid/hotrod/query/AddressBookManager.java
@@ -270,9 +270,9 @@ public class AddressBookManager {
             .having("author.name").like(namePattern).toBuilder()
             .build();
 
-      List<Person> results = query.list();
+      List<Memo> results = query.list();
       System.out.println("Found " + results.size() + " matches:");
-      for (Person p : results) {
+      for (Memo p : results) {
          System.out.println(">> " + p);
       }
    }


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1184471