### PR TITLE
BZ1292720 Carmart quickstart uses both uberjars in client-server mode…

### DIFF
--- a/carmart-tx/pom.xml
+++ b/carmart-tx/pom.xml
@@ -206,11 +206,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>javax.cache</groupId>
-            <artifactId>cache-api</artifactId>
-        </dependency>
-
         <!-- Import the infinispan core -->
         <dependency>
             <groupId>org.infinispan</groupId>

--- a/carmart/pom.xml
+++ b/carmart/pom.xml
@@ -165,11 +165,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>javax.cache</groupId>
-            <artifactId>cache-api</artifactId>
-        </dependency>
-
         <!-- Import Prettyfaces dependency. This is a UNSUPPORTED component -->
         <dependency>
             <groupId>com.ocpsoft</groupId>

--- a/carmart/pom.xml
+++ b/carmart/pom.xml
@@ -165,12 +165,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Import the infinispan core -->
-        <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-embedded</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
@@ -242,6 +236,12 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.infinispan</groupId>
+                    <artifactId>infinispan-embedded</artifactId>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -291,8 +291,7 @@
             a remote JDG running instance -->
         <profile>
             <id>remote-jbossas</id>
-            <!-- To connect to remote JDG, it is necessary to add the Hot 
-                Rod client -->
+            <!-- To connect to remote JDG, it is necessary to add the Hot Rod client -->
             <dependencies>
                 <dependency>
                     <groupId>org.infinispan</groupId>
@@ -348,6 +347,11 @@
                 It has to embed some libraries that aren't available on ews/tomcat. -->
             <id>library-tomcat</id>
             <dependencies>
+
+                <dependency>
+                    <groupId>org.infinispan</groupId>
+                    <artifactId>infinispan-embedded</artifactId>
+                </dependency>
 
                 <!-- Import the JSF 2.1 API -->
                 <dependency>
@@ -452,6 +456,12 @@
             <id>remote-tomcat</id>
             <dependencies>
 
+                <!-- To connect to remote JDG, it is necessary to add the Hot Rod client -->
+                <dependency>
+                    <groupId>org.infinispan</groupId>
+                    <artifactId>infinispan-remote</artifactId>
+                </dependency>
+
                 <!-- Import the JSF 2.1 API -->
                 <dependency>
                     <groupId>org.jboss.spec.javax.faces</groupId>
@@ -481,13 +491,6 @@
                     <artifactId>jsf-impl</artifactId>
                     <version>${version.com.sun.faces.jsf.impl}</version>
                     <scope>runtime</scope>
-                </dependency>
-                
-                <!-- To connect to remote JDG, it is necessary to add the Hot 
-                Rod client -->
-                <dependency>
-                    <groupId>org.infinispan</groupId>
-                    <artifactId>infinispan-remote</artifactId>
                 </dependency>
 
             </dependencies>

--- a/eap-cluster-app/adminApp/ejb/pom.xml
+++ b/eap-cluster-app/adminApp/ejb/pom.xml
@@ -51,10 +51,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.cache</groupId>
-            <artifactId>cache-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>

--- a/eap-cluster-app/appOne/ejb/pom.xml
+++ b/eap-cluster-app/appOne/ejb/pom.xml
@@ -51,10 +51,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.cache</groupId>
-            <artifactId>cache-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>

--- a/eap-cluster-app/appTwo/ejb/pom.xml
+++ b/eap-cluster-app/appTwo/ejb/pom.xml
@@ -51,10 +51,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.cache</groupId>
-            <artifactId>cache-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>

--- a/helloworld-jdg/pom.xml
+++ b/helloworld-jdg/pom.xml
@@ -122,11 +122,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>javax.cache</groupId>
-            <artifactId>cache-api</artifactId>
-        </dependency>
-
         <!-- Import the CDI API, we use provided scope as the API is included
             in JBoss AS 7 -->
         <dependency>


### PR DESCRIPTION
… profile
- make sure that in every profile either infinispan-embedded or infinispan-remote is used, not both

https://bugzilla.redhat.com/show_bug.cgi?id=1292720
