### PR TITLE
JDG-143 Helloworld-jdg quickstart needs to use wildfly.port property

### DIFF
--- a/helloworld-jdg/README.md
+++ b/helloworld-jdg/README.md
@@ -113,7 +113,7 @@ Undeploy the Archive
 3. When you are finished testing, type this command to undeploy the archive from both running servers:
 
         mvn wildfly:undeploy
-        mvn wildfly:undeploy -Djboss-as.port=10090
+        mvn wildfly:undeploy -Dwildfly.port=10090
 
 
 Run the Quickstart in JBoss Developer Studio or Eclipse


### PR DESCRIPTION
Fixed 1 more occurence... sorry I missed it last time.
