### PR TITLE
JDG-200 - Create sh/bat script for simplifying the eap-cluster-app quickstart run

### DIFF
--- a/eap-cluster-app/README.md
+++ b/eap-cluster-app/README.md
@@ -43,6 +43,39 @@ Configure Maven
 
 If you have not yet done so, you must [Configure Maven](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONFIGURE_MAVEN.md#configure-maven-to-build-and-deploy-the-quickstarts) before testing the quickstarts.
 
+Setup/Run the quickstart with automated script
+==============================================
+
+1. Download the EAP server and jboss-datagrid EAP modules library;
+2. Set the following two environment variables in the same shell:
+ For Linux:
+   export EAP_SERVER_ZIP_PATH=[Full path to the EAP server ZIP]
+   export JDG_MODULES_ZIP_PATH= _[Full path to the JDG EAP Modules ZIP]_
+ For Windows:
+   set EAP_SERVER_ZIP_PATH=[Full path to the EAP server ZIP]
+   set JDG_MODULES_ZIP_PATH= _[Full path to the JDG EAP Modules ZIP]_
+3. While in the root folder of the eap-cluster-app quickstart, run the following commands:
+
+For Linux:
+ 
+           ./build.sh --setup or ./build.sh --setup-domain for setting up servers and running them either in standalone or domain mode;
+           
+           ./build.sh --run for running the quickstart;
+           
+           ./build.sh --teardown for stopping the started servers as well as deleting the created directories;
+
+ For Windows:
+ 
+            build.bat --setup or build.bat --setup-domain for setting up servers and running them either in standalone or domain mode;
+            
+            build.bat --run for running the quickstart;
+            
+            build.bat --teardown for stopping the started servers as well as deleting the created directories;
+
+You can also perform all setups manually with the following steps:
+
+Setup/Run the quickstart manually
+=================================================
 
 Configure and Start the Servers in standalone mode
 --------------------------------------------------
@@ -59,8 +92,7 @@ Configure and Start the Servers in standalone mode
             For Linux:   $EAP_HOME/bin/add-user.sh -a -u quickuser -p quick-123
             For Windows: %EAP_HOME%\bin\add-user.bat -a -u quickuser -p quick-123
 
-2. Copy the prepared EAP server to 4 different directories EAP_HOME[1-4].
-3. Add the following configuration snippets to EAP's standalone.xml:
+2. Add the following configuration snippets to EAP's standalone.xml:
 
    Inside security-realms:
 
@@ -86,6 +118,8 @@ Configure and Start the Servers in standalone mode
    <outbound-socket-binding name="remote-ejb">
        <remote-destination host="localhost" port="8280"/>
    </outbound-socket-binding>
+
+3. Copy the prepared EAP server to 4 different directories EAP_HOME[1-4].
 
 4. Open a command line for each of the 4 nodes and navigate to the root of the EAP server directory.
    The following shows the command line to start the different servers:

--- a/eap-cluster-app/build.bat
+++ b/eap-cluster-app/build.bat
@@ -1,0 +1,184 @@
+@ECHO off
+SETLOCAL ENABLEEXTENSIONS
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+ECHO -------------------------------------------------------------------------
+
+ECHO eap-cluster-app quickstart setup
+
+ECHO -------------------------------------------------------------------------
+
+ECHO
+
+ECHO A simple script which sets up the quickstart, runs it and stops the servers.
+
+IF [%1] == [--setup] GOTO :SETUP
+IF [%1] == [--setup-domain] GOTO :SETUP
+IF [%1] == [--run] GOTO :RUN_QUICKSTART
+IF [%1] == [--teardown] GOTO :TEARDOWN
+
+ECHO Please provide one of the following parameters for proper script execution:
+ECHO --setup         For setting up and running EAP servers in standalone mode;
+ECHO --setup-domain  For setting up and running EAP servers in domain mode;
+ECHO --run           For running the quickstarts;
+ECHO --teardown      For stopping the started servers;
+GOTO :EOF
+
+:SETUP
+	CALL :TEARDOWN
+
+	MD setupOutput\
+	CD setupOutput
+
+	IF DEFINED JDG_MODULES_ZIP_PATH GOTO :UNZIP_JDG_MODULES
+
+	ECHO The JDG_MODULES_ZIP_PATH environment variable has not been defined
+
+	GOTO :EOF
+
+	:UNZIP_JDG_MODULES
+
+	ECHO Unzipping JDG Modules...
+
+	"%JAVA_HOME%"\bin\jar xf "%JDG_MODULES_ZIP_PATH%"
+	if errorlevel 1 (
+	   ECHO Something went wrong while extracting JDG modules by given path "%JDG_MODULES_ZIP_PATH%"
+	   exit /b %errorlevel%
+	) else (
+	   FOR /D %%a IN (*) DO (
+		SET "JDG_MODULES_HOME=%CD%\%%a"
+		GOTO :CONTINUE_WITH_EAP
+	   )
+	)
+
+	:CONTINUE_WITH_EAP
+	md eap-server\
+	cd eap-server\
+	SET "EAP_DIRS=%CD%"
+
+	IF DEFINED EAP_SERVER_ZIP_PATH GOTO :UNZIP_EAP
+
+	ECHO The EAP_SERVER_ZIP_PATH environment variable has not been defined
+
+	GOTO :EOF
+
+	:UNZIP_EAP
+	REM C:\ProgramData\Oracle\Java\javapath;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\
+	ECHO Unzipping EAP Server ...
+	"%JAVA_HOME%"\bin\jar xf "%EAP_SERVER_ZIP_PATH%"
+	if errorlevel 1 (
+	   ECHO Something went wrong while extracting EAP server by given path "%EAP_SERVER_ZIP_PATH%"
+	   exit /b %errorlevel%
+	) else (
+	   FOR /D %%a IN (*) DO (
+		SET "EAP_HOME=%CD%\%%a"
+		GOTO :CONTINUE_SETUP
+	   )
+	)
+	:CONTINUE_SETUP
+	cd ..\..
+	ECHO Copying the JDG modules to EAP Home directory..
+	XCOPY /e/i/f "%JDG_MODULES_HOME%"\modules "%EAP_HOME%"\modules >nul 2>&1
+	ECHO Adding user to EAP
+	@ECHO | call "%EAP_HOME%"\bin\add-user.bat -a -u quickuser -p quick-123 >nul 2>&1
+
+	ECHO Building quickstart ..
+	CALL mvn clean install > setupOutput\mvn_install.log
+
+	IF "%1" EQU "--setup" (
+	   ECHO Copying EAP server to directories ...
+
+	   XCOPY /e/i/f "%EAP_HOME%" "%EAP_DIRS%\server1" >nul 2>&1
+	   SET "EAP_HOME1=%EAP_DIRS%\server1"
+
+	   XCOPY /e/i/f "%EAP_HOME%" "%EAP_DIRS%\server2" >nul 2>&1
+	   SET "EAP_HOME2=%EAP_DIRS%\server2"
+
+	   XCOPY /e/i/f "%EAP_HOME%" "%EAP_DIRS%\server3" >nul 2>&1
+	   SET "EAP_HOME3=%EAP_DIRS%\server3"
+
+	   XCOPY /e/i/f "%EAP_HOME%" "%EAP_DIRS%\server4" >nul 2>&1
+	   SET "EAP_HOME4=%EAP_DIRS%\server4"
+
+	   ECHO Running quckstart in Standalon mode. Starting all 4 instances of the server...
+
+	   START /B "Running EAP node1" "!EAP_HOME1!\bin\standalone.bat" -Djboss.node.name=node1 > "!EAP_HOME1!\server.log"
+	   START /B "Running EAP node2" "!EAP_HOME2!\bin\standalone.bat" -Djboss.node.name=node2 -Djboss.socket.binding.port-offset=100 > "!EAP_HOME2!\server.log"
+	   START /B "Running EAP node3" "!EAP_HOME3!\bin\standalone.bat" -Djboss.node.name=node3 -Djboss.socket.binding.port-offset=200 -c standalone-ha.xml > "!EAP_HOME3!\server.log"
+	   START /B "Running EAP node4" "!EAP_HOME4!\bin\standalone.bat" -Djboss.node.name=node4 -Djboss.socket.binding.port-offset=300 -c standalone-ha.xml > "!EAP_HOME4!\server.log"
+
+	   ECHO Waiting for 2 minutes until the servers are started...
+	   TIMEOUT 120
+
+	   ECHO Adding the configuration for EJB server-to-server invocation ...
+	   @ECHO | CALL "!EAP_HOME1!\bin\jboss-cli.bat" -c --controller=localhost:9990 --file=install-appOne-standalone.cli > setupOutput/install.log
+	   @ECHO | CALL "!EAP_HOME2!\bin\jboss-cli.bat" -c --controller=localhost:10090 --file=install-appOne-standalone.cli >> setupOutput/install.log
+	   @ECHO | CALL "!EAP_HOME3!\bin\jboss-cli.bat" -c --controller=localhost:10190 --file=install-appOne-standalone.cli >> setupOutput/install.log
+	   @ECHO | CALL "!EAP_HOME4!\bin\jboss-cli.bat" -c --controller=localhost:10290 --file=install-appOne-standalone.cli >> setupOutput/install.log
+
+	   ECHO Waiting until the configurations are set properly..
+	   TIMEOUT 10
+
+	   ECHO Copying the resources to EAP servers..
+	   ECHO f | XCOPY /F/Y adminApp\ear\target\jboss-eap-application-adminApp.ear "!EAP_HOME1!\standalone\deployments\jboss-eap-application-adminApp.ear" >nul 2>&1
+	   ECHO f | XCOPY /F/Y appOne\ear\target\jboss-eap-application-AppOne.ear "!EAP_HOME2!\standalone\deployments\jboss-eap-application-AppOne.ear" >nul 2>&1
+	   ECHO f | XCOPY /F/Y appTwo\ear\target\jboss-eap-application-AppTwo.ear "!EAP_HOME3!\standalone\deployments\jboss-eap-application-AppTwo.ear" >nul 2>&1
+	   ECHO f | XCOPY /F/Y appTwo\ear\target\jboss-eap-application-AppTwo.ear "!EAP_HOME4!\standalone\deployments\jboss-eap-application-AppTwo.ear" >nul 2>&1
+
+	   ECHO Waiting until the servers are deployed...
+	   TIMEOUT 40
+	) ELSE (
+	   IF "%1" EQU "--setup-domain" (
+         ECHO Running quickstart in Domain Mode ..
+
+         START /B "Running EAP Server" "%EAP_HOME%\bin\domain.bat" > "%EAP_HOME%\server.log"
+         ECHO Waiting for 2 minutes until the server is started...
+         TIMEOUT 120
+
+         ECHO Applying the configuration for the quickstart, the domain will contain 4 nodes ..
+         @ECHO | CALL "%EAP_HOME%\bin\jboss-cli.bat" -c --file=install-domain.cli > setupOutput\install.log
+
+         ECHO Waiting for 75 seconds until the nodes are started for deploying the application ...
+         TIMEOUT 75
+
+         ECHO Deploying application for domain mode ...
+         @ECHO | CALL "%EAP_HOME%\bin\jboss-cli.bat" -c --file=deploy-domain.cli > setupOutput/deploy.log
+	   )
+	)
+	ECHO Setup is Done!
+	GOTO :EOF
+
+:RUN_QUICKSTART
+ 	ECHO Running the Step1.
+	ECHO 	  Add values to App1 cache with the AdminApp and validate that they are replicated to the server instance of AppOne.
+   ECHO    Add a value to App2 cache, rollback the transaction and check that it is not added to the cache after rollback.
+   ECHO    The AdminServer and the AppOneServer are not configured as JBoss EAP cluster, only the Infinispan caches are configured by the application to communicate and replicate the caches.
+
+	CALL mvn -Dexec.mainClass=org.jboss.as.quickstarts.datagrid.eap.app.AdminClient exec:java
+
+   ECHO Running Step 2:
+	ECHO 	 Add values to App2 cache with the AdminApp and access AppOne to show that the EJB invocation is clustered and both AppTwo instances are used.
+   ECHO	 Show that the JBoss EAP and Infinispan clusters are not related and the Infinispan cluster is able to use a different JGroups implementation as the JBoss EAP server.
+
+	CALL mvn -Dexec.mainClass=org.jboss.as.quickstarts.datagrid.eap.app.AppOneClient exec:java
+	GOTO :EOF
+
+:TEARDOWN
+	ECHO Stopping All Servers
+	"%JAVA_HOME%\bin\jps.exe" -v > "%TEMP%\tmp.txt"
+	for /f "tokens=1" %%f in ('find "standalone" "%TEMP%\tmp.txt"') do TSKILL %%f >nul 2>&1
+	for /f "tokens=1" %%f in ('find "process-controller" "%TEMP%\tmp.txt"') do SET process_id_domain=%%f
+
+	IF DEFINED process_id_domain TSKILL %process_id_domain% >nul 2>&1
+
+	REM Killing the child cmd.exe processes
+	TASKKILL /f /fi "STATUS eq Unknown" /im cmd.exe >nul 2>&1
+
+	ECHO Waiting 20 seconds until the servers are stopped...
+	TIMEOUT 20
+
+   IF EXIST setupOutput (
+	   ECHO Deleting output folder...
+	   RD /S /Q setupOutput
+	)
+	GOTO :EOF

--- a/eap-cluster-app/build.sh
+++ b/eap-cluster-app/build.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+#Defining colors for output
+RED='\033[0;31m'
+NO_COLOR='\033[0m'
+GREEN='\033[0;33m'
+
+case "$1" in
+    --setup | --setup-domain)
+      #Cleaning up directories from previous run
+      echo "Removing directories from previous run ..."
+      rm -rf setupOutput/
+      mkdir setupOutput
+
+      #Unzipping the EAP server to eap-server/ directory
+      echo "Unzipping EAP Server ..."
+      unzip -q ${EAP_SERVER_ZIP_PATH} -d setupOutput/eap-server
+      export EAP_HOME=`cd setupOutput/eap-server/*;pwd`
+
+      #Unzipping the JDG EAP Modules to jdg-modules directory
+      echo "Unzipping JDG Modules ..."
+      unzip -q ${JDG_MODULES_ZIP_PATH} -d setupOutput/jdg-modules
+      export JDG_MODULES=`cd setupOutput/jdg-modules/*;pwd`
+
+      echo "Copying the JDG modules to EAP Home directory"
+      cp -a "${JDG_MODULES}/modules" "${EAP_HOME}"
+
+      echo "Adding user to EAP"
+      "${EAP_HOME}"/bin/add-user.sh -a -u quickuser -p quick-123
+
+      echo "Building quickstart .."
+      mvn clean install > setupOutput/mvn_install.log
+
+      if [ "${1}" == "--setup" ]; #Starting in standalone mode otherwise in domain mode
+      then
+         echo "Copying the configurations from README file to EAP ..."
+         # modify EAP standalone.xml according to README
+         # copy <security-realm> from README to standalone.xml
+         sed '/<security-realm name="ejb-security-realm">/,/<\/security-realm>/!d' README.md > tmpbuff
+         sed '/<\/security-realms>/i \
+               INSERT-SECURITY-REALM-HERE' -i "${EAP_HOME}"/standalone/configuration/standalone.xml
+         sed '/INSERT-SECURITY-REALM-HERE/ {
+              r tmpbuff
+              d
+              }' -i "${EAP_HOME}"/standalone/configuration/standalone.xml
+
+         sed '/<outbound-connections>/,/<\/outbound-connections>/!d' README.md > tmpbuff
+         sed '/<subsystem xmlns="urn:jboss:domain:remoting:.*">/a \
+            INSERT_OUTBOUND_CONNECTION_HERE' -i "${EAP_HOME}"/standalone/configuration/standalone.xml
+         sed '/INSERT_OUTBOUND_CONNECTION_HERE/ {
+              r tmpbuff
+              d
+              }' -i "${EAP_HOME}"/standalone/configuration/standalone.xml
+
+         sed '/<outbound-socket-binding.*/,/<\/outbound-socket-binding/!d' README.md > tmpbuff
+         sed '/<\/socket-binding-group>/i \
+               INSERT-SOCKET-BINDING-HERE' -i "${EAP_HOME}"/standalone/configuration/standalone.xml
+         sed '/INSERT-SOCKET-BINDING-HERE/ {
+              r tmpbuff
+              d
+              }' -i "${EAP_HOME}"/standalone/configuration/standalone.xml
+
+         echo "Copying EAP server to directories"
+         cp -R "${EAP_HOME}" setupOutput/eap-server/server1
+         export EAP_HOME1=`cd setupOutput/eap-server/server1;pwd`
+
+         cp -R "${EAP_HOME}" setupOutput/eap-server/server2
+         export EAP_HOME2=`cd setupOutput/eap-server/server2;pwd`
+
+         cp -R "${EAP_HOME}" setupOutput/eap-server/server3
+         export EAP_HOME3=`cd setupOutput/eap-server/server3;pwd`
+
+         cp -R "${EAP_HOME}" setupOutput/eap-server/server4
+         export EAP_HOME4=`cd setupOutput/eap-server/server4;pwd`
+
+        echo "Running quckstart in Standalon mode. Starting all 4 instances of the server..."
+        sh "${EAP_HOME1}/"bin/standalone.sh -Djboss.node.name=node1 > "${EAP_HOME1}/server.log" &
+        sleep 10
+
+        sh "${EAP_HOME2}"/bin/standalone.sh -Djboss.node.name=node2 -Djboss.socket.binding.port-offset=100 > "${EAP_HOME2}/server.log" &
+        sleep 10
+
+        sh "${EAP_HOME3}"/bin/standalone.sh -Djboss.node.name=node3 -Djboss.socket.binding.port-offset=200 -c standalone-ha.xml > "${EAP_HOME3}/server.log" &
+        sleep 10
+
+        sh "${EAP_HOME4}"/bin/standalone.sh -Djboss.node.name=node4 -Djboss.socket.binding.port-offset=300 -c standalone-ha.xml > "${EAP_HOME4}/server.log" &
+        sleep 10
+
+        echo "Adding the configuration for node2 (AppOne) to use EJB server-to-server invocation ..."
+        "${EAP_HOME2}"/bin/jboss-cli.sh -c --controller=localhost:10090 --file=install-appOne-standalone.cli > setupOutput/install.log
+        sleep 10
+
+        echo "Copying the resources to EAP servers.."
+        cp adminApp/ear/target/jboss-eap-application-adminApp.ear "${EAP_HOME1}"/standalone/deployments
+        cp appOne/ear/target/jboss-eap-application-AppOne.ear "${EAP_HOME2}"/standalone/deployments
+        cp appTwo/ear/target/jboss-eap-application-AppTwo.ear "${EAP_HOME3}"/standalone/deployments
+        cp appTwo/ear/target/jboss-eap-application-AppTwo.ear "${EAP_HOME4}"/standalone/deployments
+
+        echo "Waiting for 40 seconds until the servers are deployed..."
+        sleep 40
+      else
+         echo "Running quckstart in Domain mode ..."
+         sh "${EAP_HOME}"/bin/domain.sh > "${EAP_HOME}/server.log" &
+         sleep 10
+
+         echo "Applying the configuration for the quickstart, the domain will contain 4 nodes ..."
+         "${EAP_HOME}"/bin/jboss-cli.sh -c --file=install-domain.cli > setupOutput/install.log
+
+         echo "Waiting until the nodes are started for deploying the application ..."
+         sleep 40 #Waiting for applications to start so that the next operation succeeds
+
+         echo "Deploying application for domain mode..."
+         "${EAP_HOME}"/bin/jboss-cli.sh -c --file=deploy-domain.cli > setupOutput/deploy.log
+      fi
+   ;;
+
+   --run)
+      echo -e "${GREEN}Running the Step1. Add values to App1 cache with the AdminApp and validate that they are replicated to the server instance of AppOne.
+           Add a value to App2 cache, rollback the transaction and check that it is not added to the cache after rollback.
+           The AdminServer and the AppOneServer are not configured as JBoss EAP cluster, only the Infinispan caches are configured by the application
+           to communicate and replicate the caches.${NO_COLOR}"
+      mvn -Dexec.mainClass=org.jboss.as.quickstarts.datagrid.eap.app.AdminClient exec:java
+
+      echo -e "${GREEN}Running Step 2: Add values to App2 cache with the AdminApp and access AppOne to show that the EJB invocation is clustered and both AppTwo instances are used.
+         Show that the JBoss EAP and Infinispan clusters are not related and the Infinispan cluster is able to use a different JGroups implementation as the JBoss EAP server.${NO_COLOR}"
+      mvn -Dexec.mainClass=org.jboss.as.quickstarts.datagrid.eap.app.AppOneClient exec:java
+   ;;
+
+   --teardown)
+      echo "Stopping all servers ..."
+      #Getting process ID in case if the servers were started in Domain Mode and killing it:
+      (ps -ef | grep 'Process Controller' | grep -v grep | awk '{print $2}' | xargs kill) > /dev/null 2>&1
+      (ps -ef | grep 'Standalone' | grep -v grep | awk '{print $2}' | xargs kill) > /dev/null 2>&1
+
+      rm -rf setupOutput/
+   ;;
+
+   *)
+      echo -e "${GREEN}Possible list of arguments is:"
+      echo "--setup sets up the EAP servers, starts them in standalone mode and installs quickstart configuration;"
+      echo "--setup-domain sets up the EAP servers, starts them in domain mode and installs quickstart configuration. Use this argument with --setup argument;"
+      echo "--run runs the quickstarts;"
+      echo -e "--teardown stops the servers and cleans up the folders;${NO_COLOR}"
+      exit 1;
+esac
+
+echo "Done!"

--- a/eap-cluster-app/install-appOne-standalone.cli
+++ b/eap-cluster-app/install-appOne-standalone.cli
@@ -1,6 +1,6 @@
 batch
 # Configure the connection from main server to "one" and "two"
-/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=remote-ejb:add(host=localhost, port=4647)
+/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=remote-ejb:add(host=localhost, port=8280)
 
 # add security realm
 /core-service=management/security-realm=ejb-security-realm:add()

--- a/eap-cluster-app/install-domain.cli
+++ b/eap-cluster-app/install-domain.cli
@@ -25,7 +25,7 @@ batch
 /host=master/core-service=management/security-realm=ejb-security-realm/server-identity=secret:add(value=cXVpY2stMTIz)
 
 # add the socket binding to the full-sockets, used by the AppOne server
-/socket-binding-group=full-sockets/remote-destination-outbound-socket-binding=remote-ejb:add(host=localhost, port=4647)
+/socket-binding-group=full-sockets/remote-destination-outbound-socket-binding=remote-ejb:add(host=localhost, port=8280)
 
 # add the outbound connections to the remoting subsystem of the full-profile used by AppOne server
 /profile=full/subsystem=remoting/remote-outbound-connection=remote-ejb-connection:add(outbound-socket-binding-ref=remote-ejb, security-realm=ejb-security-realm, username=quickuser)
@@ -46,9 +46,6 @@ batch
 
 #add the group and the servers for the AppOne
 # AppOne is not a clustered application, so use full profile
-
-# remove the not wanted messaging subsystem
-/profile=full/subsystem=messaging:remove
 
 /server-group=quickstart-eap-appone:add(profile=full,socket-binding-group=full-sockets)
 /server-group=quickstart-eap-appone/jvm=default:add()


### PR DESCRIPTION
Linux and Windows scripts are created for easy setup and run of the quickstart on that OSs. 
Also the README.md file is changed accordingly and one port is changed in cli file for proper installation in standalone mode.
