### PR TITLE
cdi-jdg  change to use the JDG7.1 EAP modules

### DIFF
--- a/cdi-jdg/README.md
+++ b/cdi-jdg/README.md
@@ -41,11 +41,19 @@ Build and Deploy the Application in Library Mode
 
 1. Make sure you have started EAP as described above.
 2. Open a command line and navigate to the root directory of this quickstart.
-3. Type this command to build and deploy the archive:
+3. continue with step 7 if you want to package the JDG libraries in your application (not recommended)
+   or follow step 4...6 to use the JDG modules in EAP to not bundle JDG with your version (recommended)
+4. Change the pom.xml, see the comments 'asMODULE'
+   Maybe use MANIFEST or jboss-deployment-structure.xml to declare dependencies
+5. Download the 'Library Module for JBoss EAP' from
+   https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=data.grid
+6. Apply the modules to your EAP installation as described within the downloaded modules
+7. Type this command to build and deploy the archive:
 
         mvn clean package wildfly:deploy
 
-4. This will deploy `target/infinispan-cdi.war` to the running instance of the server.
+8. This will deploy `target/infinispan-cdi.war` to the running instance of the server.
+
 
 Access the application
 ---------------------

--- a/cdi-jdg/pom.xml
+++ b/cdi-jdg/pom.xml
@@ -80,12 +80,18 @@
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
+            <!-- asMODULE  use provided scope to avoid bundling into the war file
+            <scope>provided</scope>
+            -->
         </dependency>
 
         <!-- Infinispan dependency -->
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-embedded</artifactId>
+            <!-- asMODULE  use provided scope to avoid bundling into the war file
+            <scope>provided</scope>
+            -->
         </dependency>
 
         <!-- Test dependencies -->
@@ -118,6 +124,12 @@
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
+                        <!-- asMODULE  add dependencies for the modules in EAP
+                             alternative you might rename src/main/webapp/WEB-INF/jboss-deployment-structure.xml.alternative
+                        <manifestEntries>
+                            <Dependencies>org.infinispan.cdi.embedded:jdg-7.1 annotations meta-inf, org.infinispan.jcache:jdg-7.1 annotations meta-inf</Dependencies>
+                        </manifestEntries>
+                        -->
                     </archive>
                 </configuration>
             </plugin>

--- a/cdi-jdg/src/main/webapp/WEB-INF/jboss-deployment-structure.xml.alternative
+++ b/cdi-jdg/src/main/webapp/WEB-INF/jboss-deployment-structure.xml.alternative
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>  
+<jboss-deployment-structure>
+    <deployment>
+        <dependencies>
+           <module name="org.infinispan.cdi.embedded" slot="jdg-7.1"  meta-inf="import" annotations="true"/>
+            <module name="org.infinispan.jcache" slot="jdg-7.1"  meta-inf="import" annotations="true"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>


### PR DESCRIPTION
Added README instructions and entries for pom.xml or jboss-deployment-structure.xml to use the JDG-EAP modules