### PR TITLE
JDG-998 CDI quickstar now uses modules

### DIFF
--- a/cdi-jdg/README.md
+++ b/cdi-jdg/README.md
@@ -11,7 +11,10 @@ Source: <https://github.com/infinispan/jdg-quickstart>
 What is it?
 -----------
 
-The `cdi-jdg` quickstart demontrates injection of Infinispan caches into a web application using CDI.
+The `cdi-jdg` quickstart demontrates injection of Infinispan caches into a web application using CDI. It it worth to mention
+that dependencies used in this quickstart needs to be present in EAP instance. In other words, one needs to JDG
+EAP modules. If one wishes to run this quickstart without EAP modules, the scope of JDG dependencies must be changed
+from `provided` into `compile`. A manifest entry with dependencies also needs to be removed.
 
 Additionally, this quickstart uses JCache integration which makes accessing Cache much easier.
 

--- a/cdi-jdg/pom.xml
+++ b/cdi-jdg/pom.xml
@@ -80,18 +80,14 @@
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
-            <!-- asMODULE  use provided scope to avoid bundling into the war file
             <scope>provided</scope>
-            -->
         </dependency>
 
         <!-- Infinispan dependency -->
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-embedded</artifactId>
-            <!-- asMODULE  use provided scope to avoid bundling into the war file
             <scope>provided</scope>
-            -->
         </dependency>
 
         <!-- Test dependencies -->
@@ -124,12 +120,9 @@
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
-                        <!-- asMODULE  add dependencies for the modules in EAP
-                             alternative you might rename src/main/webapp/WEB-INF/jboss-deployment-structure.xml.alternative
                         <manifestEntries>
-                            <Dependencies>org.infinispan.cdi.embedded:jdg-7.1 annotations meta-inf, org.infinispan.jcache:jdg-7.1 annotations meta-inf</Dependencies>
+                            <Dependencies>org.infinispan.cdi.embedded:jdg-7.1 services meta-inf</Dependencies>
                         </manifestEntries>
-                        -->
                     </archive>
                 </configuration>
             </plugin>


### PR DESCRIPTION
https://issues.jboss.org/browse/JDG-998

I've changed the way we use dependencies in this quickstart (@wfink mentioned that this is the recommended configuration). It turned out that no Jandex indexing file is needed.