### PR TITLE
Version updates (since DR2) and resulting build fixes

### DIFF
--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <version.org.infinispan>8.5.0-redhat-SNAPSHOT</version.org.infinispan>
-        <version.jdg.hadoop>0.2.0.Final-redhat-1</version.jdg.hadoop>
+        <version.jdg.hadoop>0.2.0.Final-redhat-2</version.jdg.hadoop>
         <version.flink>1.0.0</version.flink>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -43,7 +43,7 @@
         <version.org.infinispan>8.5.0-redhat-SNAPSHOT</version.org.infinispan>
         <version.spark.connector>7.2.0-redhat-SNAPSHOT</version.spark.connector>
 
-        <version.spark>2.0.0</version.spark>
+        <version.spark>2.1.0</version.spark>
 
         <!-- maven-compiler-plugin -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
I've updated two dependency versions, and the spark one (result of an update of spark in jdg-spark)
caused a compilation failure that i needed to fix quickly so I could proceed with the release.

@gustavonalle Please check if the fixes are correct and complete.