### PR TITLE
JDG-1398 cdi-jdg quickstart jcache fix

### DIFF
--- a/cdi-jdg/README.md
+++ b/cdi-jdg/README.md
@@ -11,7 +11,7 @@ Source: <https://github.com/infinispan/jdg-quickstart>
 What is it?
 -----------
 
-The `cdi-jdg` quickstart demontrates injection of Infinispan caches into a web application using CDI. It it worth to mention
+The `cdi-jdg` quickstart demonstrates injection of Infinispan caches into a web application using CDI. It it worth to mention
 that dependencies used in this quickstart needs to be present in EAP instance. In other words, one needs to install JDG
 EAP modules. If one wishes to run this quickstart without EAP modules, the scope of JDG dependencies must be changed
 from `provided` into `compile`. A manifest entry with dependencies also needs to be removed.

--- a/cdi-jdg/README.md
+++ b/cdi-jdg/README.md
@@ -12,7 +12,7 @@ What is it?
 -----------
 
 The `cdi-jdg` quickstart demontrates injection of Infinispan caches into a web application using CDI. It it worth to mention
-that dependencies used in this quickstart needs to be present in EAP instance. In other words, one needs to JDG
+that dependencies used in this quickstart needs to be present in EAP instance. In other words, one needs to install JDG
 EAP modules. If one wishes to run this quickstart without EAP modules, the scope of JDG dependencies must be changed
 from `provided` into `compile`. A manifest entry with dependencies also needs to be removed.
 
@@ -29,6 +29,11 @@ Configure Maven
 ---------------
 
 If you have not yet done so, you must [Configure Maven](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONFIGURE_MAVEN.md#configure-maven-to-build-and-deploy-the-quickstarts) before testing the quickstarts.
+
+Install EAP Modules
+--------------------
+
+Download JDG EAP modules and copy them to `%JBOSS_HOME%/modules` directory. 
 
 Start EAP
 ---------
@@ -48,6 +53,7 @@ Build and Deploy the Application in Library Mode
 1. Make sure you have started EAP as described above.
 2. Open a command line and navigate to the root directory of this quickstart.
 3. Type this command to build and deploy the archive:
+
 
         mvn clean package wildfly:deploy
 

--- a/cdi-jdg/pom.xml
+++ b/cdi-jdg/pom.xml
@@ -121,7 +121,7 @@
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
                         <manifestEntries>
-                            <Dependencies>org.infinispan.cdi.embedded:jdg-7.1 services meta-inf</Dependencies>
+                            <Dependencies>org.infinispan.cdi.embedded:jdg-7.1 services meta-inf, org.infinispan.jcache:jdg-7.1 services meta-inf</Dependencies>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/cdi-jdg/pom.xml
+++ b/cdi-jdg/pom.xml
@@ -121,7 +121,8 @@
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
                         <manifestEntries>
-                            <Dependencies>org.infinispan.cdi.embedded:jdg-7.1 services meta-inf, org.infinispan.jcache:jdg-7.1 services meta-inf</Dependencies>
+                            <Dependencies>org.infinispan.cdi.embedded:jdg-7.2 services meta-inf,
+                                org.infinispan.jcache:jdg-7.2 services meta-inf</Dependencies>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/cdi-jdg/src/main/java/org/infinispan/quickstart/cdi/GreetingCacheManager.java
+++ b/cdi-jdg/src/main/java/org/infinispan/quickstart/cdi/GreetingCacheManager.java
@@ -58,12 +58,12 @@ public class GreetingCacheManager {
         return cache.size();
     }
 
-    public EvictionStrategy getEvictionStrategy() {
-        return cache.getCacheConfiguration().eviction().strategy();
+    public EvictionType getEvictionType() {
+        return cache.getCacheConfiguration().memory().evictionType();
     }
 
     public long getEvictionMaxEntries() {
-        return cache.getCacheConfiguration().eviction().maxEntries();
+        return cache.getCacheConfiguration().memory().size()
     }
 
     public String[] getCachedValues() {

--- a/cdi-jdg/src/main/java/org/infinispan/quickstart/cdi/config/Config.java
+++ b/cdi-jdg/src/main/java/org/infinispan/quickstart/cdi/config/Config.java
@@ -58,9 +58,7 @@ public class Config {
     @ConfigureCache("greeting-cache")
     @Produces
     public Configuration greetingCache() {
-        return new ConfigurationBuilder()
-                .eviction().strategy(EvictionStrategy.LRU).maxEntries(4)
-                .build();
+        return new ConfigurationBuilder().memory().evictionType(EvictionType.COUNT).size(4).build();
     }
 
     /**

--- a/cdi-jdg/src/main/webapp/WEB-INF/beans.xml
+++ b/cdi-jdg/src/main/webapp/WEB-INF/beans.xml
@@ -24,4 +24,13 @@
 <beans xmlns="http://java.sun.com/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+
+    <!-- Enable JCACHE interceptors -->
+    <interceptors>
+        <class>org.infinispan.jcache.annotation.InjectedCachePutInterceptor</class>
+        <class>org.infinispan.jcache.annotation.InjectedCacheResultInterceptor</class>
+        <class>org.infinispan.jcache.annotation.InjectedCacheRemoveEntryInterceptor</class>
+        <class>org.infinispan.jcache.annotation.InjectedCacheRemoveAllInterceptor</class>
+    </interceptors>
+
 </beans>

--- a/cdi-jdg/src/main/webapp/WEB-INF/jboss-deployment-structure.xml.alternative
+++ b/cdi-jdg/src/main/webapp/WEB-INF/jboss-deployment-structure.xml.alternative
@@ -2,8 +2,8 @@
 <jboss-deployment-structure>
     <deployment>
         <dependencies>
-           <module name="org.infinispan.cdi.embedded" slot="jdg-7.1"  meta-inf="import" annotations="true"/>
-            <module name="org.infinispan.jcache" slot="jdg-7.1"  meta-inf="import" annotations="true"/>
+           <module name="org.infinispan.cdi.embedded" slot="jdg-7.2"  meta-inf="import" annotations="true"/>
+            <module name="org.infinispan.jcache" slot="jdg-7.2"  meta-inf="import" annotations="true"/>
         </dependencies>
     </deployment>
 </jboss-deployment-structure>

--- a/cdi-jdg/src/main/webapp/index.xhtml
+++ b/cdi-jdg/src/main/webapp/index.xhtml
@@ -68,7 +68,7 @@
                         <h:outputText value="Cache name: #{greetingCacheManager.cacheName}"/>
                     </li>
                     <li>
-                        <h:outputText value="Eviction strategy: #{greetingCacheManager.evictionStrategy}"/>
+                        <h:outputText value="Eviction type: #{greetingCacheManager.evictionType}"/>
                     </li>
                     <li>
                         <h:outputText value="Max entries: #{greetingCacheManager.evictionMaxEntries}"/>

--- a/cdi-jdg/src/test/java/org/infinispan/quickstart/cdi/test/GreetingCacheManagerTest.java
+++ b/cdi-jdg/src/test/java/org/infinispan/quickstart/cdi/test/GreetingCacheManagerTest.java
@@ -58,7 +58,7 @@ public class GreetingCacheManagerTest {
     public void testGreetingCacheConfiguration() {
         assertEquals("greeting-cache", greetingCacheManager.getCacheName());
         assertEquals(4, greetingCacheManager.getEvictionMaxEntries());
-        assertEquals(EvictionStrategy.LRU, greetingCacheManager.getEvictionStrategy());
+        assertEquals(EvictionType.COUNT, greetingCacheManager.getEvictionType());
 
     }
 

--- a/eap-cluster-app/adminApp/ear/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/eap-cluster-app/adminApp/ear/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -4,7 +4,7 @@
     <sub-deployment name="ejb.jar">
         <!-- use the provided JDG modules  -->
         <dependencies>
-            <module name="org.infinispan" slot="jdg-7.1" services="export"/>
+            <module name="org.infinispan" slot="jdg-7.2" services="export"/>
         </dependencies>
     </sub-deployment>
 </jboss-deployment-structure>

--- a/eap-cluster-app/appOne/ear/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/eap-cluster-app/appOne/ear/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -4,7 +4,7 @@
     <sub-deployment name="ejb.jar">
         <!-- use the provided JDG modules -->
         <dependencies>
-            <module name="org.infinispan" slot="jdg-7.1" services="export"/>
+            <module name="org.infinispan" slot="jdg-7.2" services="export"/>
         </dependencies>
     </sub-deployment>
 </jboss-deployment-structure>

--- a/eap-cluster-app/appTwo/ear/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/eap-cluster-app/appTwo/ear/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -4,7 +4,7 @@
     <sub-deployment name="ejb.jar">
         <!-- use the provided JDG modules -->
         <dependencies>
-            <module name="org.infinispan" slot="jdg-7.1" services="export"/>
+            <module name="org.infinispan" slot="jdg-7.2" services="export"/>
         </dependencies>
     </sub-deployment>
 


### PR DESCRIPTION
Fix JCache by adding interceptor and updated dependencies. 
Changed eviction configuration because of deprecated methods.
