### PR TITLE
Disable caching service quickstart and update version to 7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </licenses>
 
     <modules>
-        <!--module>caching-service</module-->
+        <module>caching-service</module>
         <module>spring</module>
         <module>spring-session</module>
         <module>carmart</module>
@@ -62,8 +62,7 @@
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <product.version>7.3.0</product.version>
-        <product.milestone>redhat-SNAPSHOT</product.milestone>
+        <product.version>7.3.0-SNAPSHOT</product.version>
     </properties>
 
     <profiles>
@@ -90,7 +89,7 @@
 		                 <descriptors>
 		                   <descriptor>src/main/assemblies/sources.xml</descriptor>
 		                </descriptors>
-		                <finalName>jboss-datagrid-${product.version}.${product.milestone}-quickstarts</finalName>
+		                <finalName>jboss-datagrid-${product.version}-quickstarts</finalName>
 		                <appendAssemblyId>false</appendAssemblyId>
 		             </configuration>
 		          </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </licenses>
 
     <modules>
-        <module>caching-service</module>
+        <!--module>caching-service</module-->
         <module>spring</module>
         <module>spring-session</module>
         <module>carmart</module>
@@ -62,7 +62,7 @@
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <product.version>7.2.2</product.version>
+        <product.version>7.3.0</product.version>
         <product.milestone>redhat-SNAPSHOT</product.milestone>
     </properties>
 


### PR DESCRIPTION
The caching service quickstart seems to be looking for a docker environment, which prevents that from building inside a docker image.