### PR TITLE
skip fabric8 plugin, add docker profile

### DIFF
--- a/caching-service/README.md
+++ b/caching-service/README.md
@@ -47,19 +47,19 @@ Build the Quickstart
 
 Type this command to build the quickstart:
 
-        mvn clean package
+        mvn clean package -P docker
 
 Run the Quickstart on Openshift
 ------------------
 
 Run the following command
 
-        mvn fabric8:run
+        mvn fabric8:run -P docker
 
 This will deploy this service into OpenShift and connect to a default deployed Online Service. The plugin uses already configured and connected
  `oc` or `kubectl` client, so make sure you are already authenticated and proper Project has been selected.
 
-The expected output should be displayed on the console (the same that was used to invoke `mvn fabric8:run`).
+The expected output should be displayed on the console (the same that was used to invoke `mvn fabric8:run -P docker`).
 Here is an example of the command's output:
 
         ...
@@ -104,7 +104,7 @@ Run the Quickstart Locally
 ------------------
 Run the following command
 
-        mvn exec:java
+        mvn exec:java -P docker
 
 This will attempt to connect to an external openshift instance running a caching-service. This quickstart uses already
 configured and connected `oc` client, so make sure you are already authenticated and the correct project has been selected.

--- a/caching-service/pom.xml
+++ b/caching-service/pom.xml
@@ -60,7 +60,49 @@
             <version>${openshift-client.version}</version>
         </dependency>
     </dependencies>
-
+    <profiles>
+        <profile>
+            <id>docker</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <version>${fabric8-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>resource</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <generator>
+                                <includes>
+                                    <include>java-exec</include>
+                                </includes>
+                            </generator>
+                            <images>
+                                <image>
+                                    <name>${fabric8-maven-plugin.image.name}</name>
+                                    <build>
+                                        <from>${fabric8-maven-plugin.from.image}</from>
+                                        <assembly>
+                                            <descriptorRef>artifact</descriptorRef>
+                                        </assembly>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
     <build>
         <plugins>
             <plugin>
@@ -82,37 +124,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>io.fabric8</groupId>
-                <artifactId>fabric8-maven-plugin</artifactId>
-                <version>${fabric8-maven-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>resource</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <generator>
-                        <includes>
-                            <include>java-exec</include>
-                        </includes>
-                    </generator>
-                    <images>
-                        <image>
-                            <name>${fabric8-maven-plugin.image.name}</name>
-                            <build>
-                                <from>${fabric8-maven-plugin.from.image}</from>
-                                <assembly>
-                                    <descriptorRef>artifact</descriptorRef>
-                                </assembly>
-                            </build>
-                        </image>
-                    </images>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/embedded-openshift/README.md
+++ b/embedded-openshift/README.md
@@ -48,7 +48,7 @@ To build the quickstart application, do the following:
 2. Build the application `JAR` file.
 
   ```bash
-  $ mvn clean package
+  $ mvn clean package -P docker
   ```
 
   This command creates `target/jboss-embedded-openshift-quickstart.jar`. The `target/` directory also contains a Dockerfile and other deployment artifacts. The `target/classes/META-INF/fabric8` directory contains Kubernetes and OpenShift deployment templates.
@@ -56,7 +56,7 @@ To build the quickstart application, do the following:
 3. Deploy the quickstart application to OpenShift.
 
   ```bash
-  $ mvn fabric8:run
+  $ mvn fabric8:run -P docker
   ```
 
   This command uses the OpenShift source-to-image build process to create an image stream, deployment configuration, and pod named `jboss-embedded-openshift-quickstart`.

--- a/embedded-openshift/pom.xml
+++ b/embedded-openshift/pom.xml
@@ -64,9 +64,7 @@
         <profile>
             <id>docker</id>
             <activation>
-                <file>
-                    <exists>/var/run/docker.sock</exists>
-                </file>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
     <modules>
         <module>caching-service</module>
+        <module>embedded-openshift</module>
         <module>spring</module>
         <module>spring-session</module>
         <module>carmart</module>
@@ -55,7 +56,6 @@
         <module>spark</module>
         <module>hadoop</module>
         <module>remote-tasks-with-streams</module>
-        <module>embedded-openshift</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This PR skips fabric8 plugin on build.
Fabric8 needs docker, and it's very useful to run the examples in Openshift.
This PR adds the profile 'docker' and updates quickstarts so explicitly we build using 'docker' profile when we are testing these quickstarts.
