### PR TITLE
Fix wrong script within eap-datagrid-subsystem for localCache creation

### DIFF
--- a/eap-datagrid-subsystem/install2-standalone-local.cli
+++ b/eap-datagrid-subsystem/install2-standalone-local.cli
@@ -1,3 +1,3 @@
 # add a local cache
 # This must be done after the server is restarted if running the install1 script
-/subsystem=datagrid-infinispan/cache-container=jdg-container/distributed-cache=EAPcache:add(configuration=localDefault)
+/subsystem=datagrid-infinispan/cache-container=jdg-container/local-cache=EAPcache:add(configuration=localDefault)


### PR DESCRIPTION
The script will create a clustered cache instead of a local one.
This will not work correctly