### PR TITLE
Fix version for org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec:jar is missing

### DIFF
--- a/carmart-tx/pom.xml
+++ b/carmart-tx/pom.xml
@@ -297,6 +297,7 @@
                 <dependency>
                     <groupId>org.jboss.spec.javax.transaction</groupId>
                     <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+                    <version>${version.jboss-transaction-api_1.1_spec}</version>
                     <scope>compile</scope>
                 </dependency>
 


### PR DESCRIPTION
Fix version for org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec:jar is missing

The command `mvn clean package -Plibrary-tomcat` was failing