### PR TITLE
fixing dependency issue on carmart project

### DIFF
--- a/carmart/pom.xml
+++ b/carmart/pom.xml
@@ -37,6 +37,7 @@
         <version.org.infinispan>9.4.1-SNAPSHOT</version.org.infinispan>
 
         <version.jboss.spec.javaee.7.0>9.0.1.Final</version.jboss.spec.javaee.7.0>
+        <version.jboss-transaction-api_1.1_spec>1.0.1.Final</version.jboss-transaction-api_1.1_spec>
 
         <version.commons.logging>1.1.1</version.commons.logging>
         <version.commons.codec>1.10</version.commons.codec>
@@ -317,6 +318,7 @@
                 <dependency>
                     <groupId>org.jboss.spec.javax.transaction</groupId>
                     <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+                    <version>${version.jboss-transaction-api_1.1_spec}</version>
                 </dependency>
 
                 <!-- Import the WELD "uber-jar", meaning it bundles all the 


### PR DESCRIPTION
Fixing the following error
```
[ERROR]   The project org.jboss.quickstarts.jdg:jboss-carmart:7.3.0.Final-redhat-00001 (/home/jenkins/workspace/jdg-func-quickstarts-CR1-gustavo/d192516b/jdg-quickstart/jboss-datagrid-7.3.0-quickstarts/carmart/pom.xml) has 1 error
[ERROR]     'dependencies.dependency.version' for org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec:jar is missing. @ line 317, column 29
```