### PR TITLE
JDG-2722 Spring4/Spring5 quick starts are missing from jboss-datagrid-7.3.1.ER4-quickstarts.zip

### DIFF
--- a/src/main/assemblies/sources.xml
+++ b/src/main/assemblies/sources.xml
@@ -63,8 +63,10 @@
                 <include>rest-endpoint/**</include>
                 <include>secure-embedded-cache/**</include>
                 <include>spark/**</include>
-                <include>spring/**</include>
-                <include>spring-session/**</include>
+                <include>spring4/**</include>
+                <include>spring4-session/**</include>
+                <include>spring5/**</include>
+                <include>spring5-session/**</include>
                 <include>settings.xml</include>
                 <include>README.md</include>
                 <include>LICENSE.txt</include>


### PR DESCRIPTION
Added spring4/5 quickstart to distribution zip