### PR TITLE
JDG-2802 - Add memcached connector config

### DIFF
--- a/memcached-endpoint/README.md
+++ b/memcached-endpoint/README.md
@@ -67,7 +67,7 @@ Configure JDG
 
 * Infinispan subsystem definition:
 
-        <subsystem xmlns="urn:infinispan:server:core:8.5" default-cache-container="local">
+        <subsystem xmlns="urn:infinispan:server:core:9.4" default-cache-container="local">
             <cache-container name="local" default-cache="default">
                 <local-cache name="default" start="EAGER">
                     <locking acquire-timeout="30000" concurrency-level="1000" striping="false"/>
@@ -105,6 +105,12 @@ Configure JDG
 
             </cache-container>
             <cache-container name="security"/>
+        </subsystem>
+
+* Memcached connector definition
+
+        <subsystem xmlns="urn:infinispan:server:endpoint:9.4">
+            <memcached-connector socket-binding="memcached" cache-container="local"/>
         </subsystem>
     
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JDG-2802 Quickstart is missing memcached connector config.