### PR TITLE
JDG-2816 spark quickstart fix

### DIFF
--- a/caching-service/pom.xml
+++ b/caching-service/pom.xml
@@ -22,7 +22,7 @@
         <fabric8-maven-plugin.image.name>%g/%a:%v</fabric8-maven-plugin.image.name>
         <shade-maven-plugin.main.class>org.infinispan.demo.online.DeployedOpenShiftClient</shade-maven-plugin.main.class>
         <exec-java.main.class>org.infinispan.demo.online.ExternalOpenShiftClient</exec-java.main.class>
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
     </properties>
 
     <dependencyManagement>

--- a/camel-jbossdatagrid-fuse/pom.xml
+++ b/camel-jbossdatagrid-fuse/pom.xml
@@ -24,7 +24,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
       <version.camel.components>7.2.0.Final-redhat-9</version.camel.components>
-      <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+      <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
       <version.camel-jbossdatagrid>7.2.0.Final-redhat-9</version.camel-jbossdatagrid>
    </properties>
 

--- a/carmart-tx/pom.xml
+++ b/carmart-tx/pom.xml
@@ -30,7 +30,7 @@
         <version.jboss.weld>2.2.6.Final</version.jboss.weld>
         <version.com.sun.faces.jsf.impl>2.2.12</version.com.sun.faces.jsf.impl>
 
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
 
         <version.jboss.spec.javaee.7.0>9.0.1.Final</version.jboss.spec.javaee.7.0>
 

--- a/carmart/pom.xml
+++ b/carmart/pom.xml
@@ -34,7 +34,7 @@
             can deploy this quickstart on EWS/Tomcat through this URL -->
         <tomcat.management.url>http://localhost:8080/manager/text</tomcat.management.url>
 
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
 
         <version.jboss.spec.javaee.7.0>9.0.1.Final</version.jboss.spec.javaee.7.0>
         <version.jboss-transaction-api_1.1_spec>1.0.1.Final</version.jboss-transaction-api_1.1_spec>

--- a/cdi-jdg/pom.xml
+++ b/cdi-jdg/pom.xml
@@ -34,7 +34,7 @@
         <maven.test.skip>true</maven.test.skip>
         <version.jboss.spec.javaee.7.0>9.0.1.Final</version.jboss.spec.javaee.7.0>
         <version.war.plugin>2.6</version.war.plugin>
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
         <version.jboss.spec.javaee.7.0>9.0.1.Final</version.jboss.spec.javaee.7.0>
         <version.javax.annotation>1.3.2</version.javax.annotation>
     </properties>

--- a/eap-cluster-app/pom.xml
+++ b/eap-cluster-app/pom.xml
@@ -53,7 +53,7 @@
 
         <version.jboss.spec.javaee.6.0>3.0.3.Final</version.jboss.spec.javaee.6.0>
 
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
 
         <!-- maven-compiler-plugin -->
         <compiler.plugin.version>3.1</compiler.plugin.version>

--- a/eap-datagrid-subsystem/pom.xml
+++ b/eap-datagrid-subsystem/pom.xml
@@ -53,7 +53,7 @@
 
         <version.jboss.spec.javaee.6.0>3.0.3.Final</version.jboss.spec.javaee.6.0>
 
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
 
         <!-- maven-compiler-plugin -->
         <compiler.plugin.version>3.1</compiler.plugin.version>

--- a/embedded-openshift/pom.xml
+++ b/embedded-openshift/pom.xml
@@ -25,7 +25,7 @@
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
 
         <!-- Set properties for the maven-compiler-plugin. -->
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -33,7 +33,7 @@
     </licenses>
 
     <properties>
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
         <version.jdg.hadoop>0.4.0.Final-redhat-00001</version.jdg.hadoop>
         <version.org.apache.flink>1.7.1</version.org.apache.flink>
         <version.org.apache.hadoop>3.1.1.redhat-00002</version.org.apache.hadoop>

--- a/helloworld-jdg/pom.xml
+++ b/helloworld-jdg/pom.xml
@@ -24,7 +24,7 @@
         resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
 
         <version.jboss.spec.javaee.7.0>9.0.1.Final</version.jboss.spec.javaee.7.0>
 

--- a/hotrod-endpoint/pom.xml
+++ b/hotrod-endpoint/pom.xml
@@ -43,7 +43,7 @@
             command -->
         <main.class.hotrod-endpoint>org.jboss.as.quickstarts.datagrid.hotrod.FootballManager</main.class.hotrod-endpoint>
 
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
 
         <!-- other plugin versions -->
         <exec.plugin.version>1.2.1</exec.plugin.version>

--- a/hotrod-secured/pom.xml
+++ b/hotrod-secured/pom.xml
@@ -43,7 +43,7 @@
             command -->
         <main.class.hotrod-endpoint>org.jboss.as.quickstarts.datagrid.hotrod.FootballManager</main.class.hotrod-endpoint>
 
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
 
         <!-- other plugin versions -->
         <exec.plugin.version>1.2.1</exec.plugin.version>

--- a/hotrod-transactions/pom.xml
+++ b/hotrod-transactions/pom.xml
@@ -43,7 +43,7 @@
             command -->
         <main.class.hotrod-endpoint>org.jboss.as.quickstarts.datagrid.hotrod.FootballManager</main.class.hotrod-endpoint>
 
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
 
         <!-- other plugin versions -->
         <exec.plugin.version>1.2.1</exec.plugin.version>

--- a/rapid-stock-market/pom.xml
+++ b/rapid-stock-market/pom.xml
@@ -40,7 +40,7 @@
       <maven.compiler.target>1.8</maven.compiler.target>
       <maven.compiler.source>1.8</maven.compiler.source>
 
-      <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+      <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
       <commons.httpclient.version>3.1</commons.httpclient.version>
    </properties>
 

--- a/remote-query/pom.xml
+++ b/remote-query/pom.xml
@@ -39,7 +39,7 @@
             resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
 
         <!-- other plugin versions -->
         <exec.plugin.version>1.2.1</exec.plugin.version>

--- a/remote-tasks-with-streams/pom.xml
+++ b/remote-tasks-with-streams/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
         <exec.plugin.version>1.2.1</exec.plugin.version>
         <main.class>org.jboss.as.quickstarts.datagrid.remotetasks.LibraryManager</main.class>
 

--- a/secure-embedded-cache/pom.xml
+++ b/secure-embedded-cache/pom.xml
@@ -25,7 +25,7 @@
       <maven.compiler.target>1.8</maven.compiler.target>
 
       <version.jboss.spec.javaee.7.0>9.0.1.Final</version.jboss.spec.javaee.7.0>
-      <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+      <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
    </properties>
 
    <dependencyManagement>

--- a/spark/README.md
+++ b/spark/README.md
@@ -22,10 +22,10 @@ to get notified when a temperature average changed.
 System requirements
 -------------------
 
- * JDK 8+
+ * JDK 8, since Spark does not work yet with java 9+
  * Maven 3+
  * JBoss Data Grid 7.3.x
- * Apache Spark 2.0.2+
+ * Apache Spark 2.3
 
 Configure Maven
 ---------------

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -43,7 +43,7 @@
         <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
         <version.spark.connector>0.10.0.Final-redhat-00004</version.spark.connector>
 
-        <version.spark>2.2.0</version.spark>
+        <version.spark>2.3.3</version.spark>
 
         <!-- maven-compiler-plugin -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -40,8 +40,8 @@
     </modules>
 
     <properties>
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
-        <version.spark.connector>0.6.0.Final-redhat-9</version.spark.connector>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
+        <version.spark.connector>0.10.0.Final-redhat-00004</version.spark.connector>
 
         <version.spark>2.2.0</version.spark>
 

--- a/spark/spark-temperature-analysis/pom.xml
+++ b/spark/spark-temperature-analysis/pom.xml
@@ -67,6 +67,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scalaVersion>2.11.12</scalaVersion>
+                    <sendJavaToScalac>false</sendJavaToScalac>
+                    <args>
+                        <arg>-nobootcp</arg>
+                    </args>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/spark/temperature-client/src/main/java/org/infinispan/quickstart/spark/TemperatureClient.java
+++ b/spark/temperature-client/src/main/java/org/infinispan/quickstart/spark/TemperatureClient.java
@@ -1,5 +1,11 @@
 package org.infinispan.quickstart.spark;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
@@ -10,19 +16,15 @@ import org.infinispan.client.hotrod.event.ClientCacheEntryCreatedEvent;
 import org.infinispan.client.hotrod.event.ClientCacheEntryModifiedEvent;
 import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 /**
  * <p>
- * Simulates client application, which is interested on most up-to-date average
- * temperature in specified places. It uses Data Grid {@link ClientListener}
- * for obtaining notifications that the average temperature has changed for the subscribed cities.
+ * Simulates client application, which is interested on most up-to-date average temperature in specified places. It uses
+ * Data Grid {@link ClientListener} for obtaining notifications that the average temperature has changed for the
+ * subscribed cities.
  * </p>
  * <p>
- * The TemperatureClient needs at least one argument - place where we are interested in
- * average temperature changes. In can be also a comma separated list of places.
+ * The TemperatureClient needs at least one argument - place where we are interested in average temperature changes. In
+ * can be also a comma separated list of places.
  * </p>
  *
  * @author vjuranek
@@ -61,8 +63,8 @@ public class TemperatureClient {
    }
 
    /**
-    * Listens for updates in avg. temperature cache and takes action (printing
-    * to std. out) when avg. temperature in watched place has changed.
+    * Listens for updates in avg. temperature cache and takes action (printing to std. out) when avg. temperature in
+    * watched place has changed.
     *
     * @author vjuranek
     */
@@ -71,10 +73,12 @@ public class TemperatureClient {
    public static class AvgTemperatureListener {
       private final RemoteCache<String, Double> cache;
       private final Set<String> watchedPlaces;
+      private final ExecutorService executorService;
 
       public AvgTemperatureListener(RemoteCache<String, Double> cache, Set<String> watchedPlaces) {
          this.cache = cache;
          this.watchedPlaces = watchedPlaces;
+         this.executorService = Executors.newSingleThreadExecutor();
       }
 
       @ClientCacheEntryCreated
@@ -90,7 +94,7 @@ public class TemperatureClient {
       }
 
       private void updateAction(String key) {
-         System.out.printf("[%s] avg. temperature is now %.1f \u00B0C%n", key, cache.get(key));
+         executorService.submit(() -> System.out.printf("[%s] avg. temperature is now %.1f \u00B0C%n", key, cache.get(key)));
       }
    }
 }

--- a/spring4-session/pom.xml
+++ b/spring4-session/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
         <version.spring-boot>1.5.16.RELEASE</version.spring-boot>
         <version.spring-session>1.3.0.RELEASE</version.spring-session>
         <version.jboss-transaction-api_1.1_spec>1.0.1.Final</version.jboss-transaction-api_1.1_spec>

--- a/spring4/pom.xml
+++ b/spring4/pom.xml
@@ -19,7 +19,7 @@
         <version.spring-boot-starter-parent>1.5.16.RELEASE</version.spring-boot-starter-parent>
         <version.jboss-transaction-api_1.1_spec>1.0.1.Final</version.jboss-transaction-api_1.1_spec>
 
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
     </properties>
 
     <dependencyManagement>

--- a/spring5-session/pom.xml
+++ b/spring5-session/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
         <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
         <version.jboss-transaction-api_1.1_spec>1.0.1.Final</version.jboss-transaction-api_1.1_spec>
     </properties>

--- a/spring5/pom.xml
+++ b/spring5/pom.xml
@@ -19,7 +19,7 @@
         <version.spring-boot-starter-parent>2.1.1.RELEASE</version.spring-boot-starter-parent>
         <version.jboss-transaction-api_1.1_spec>1.0.1.Final</version.jboss-transaction-api_1.1_spec>
 
-        <version.org.infinispan>9.4.6.Final</version.org.infinispan>
+        <version.org.infinispan>9.4.13.Final-redhat-00002</version.org.infinispan>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
The quickstart is pointing to upstream dependencies. This should be changed but it should work now
with the connector 0.9 and spark 2.3.3

https://issues.jboss.org/browse/JDG-2816