### PR TITLE
Jdg 4024 logging configuration

### DIFF
--- a/openshift/datagrid-service/user-config/configuration/standalone.xml
+++ b/openshift/datagrid-service/user-config/configuration/standalone.xml
@@ -14,6 +14,7 @@
         <extension module="org.jboss.as.security"/>
         <extension module="org.jboss.as.transactions"/>
         <extension module="org.jgroups.extension"/>
+        <extension module="org.wildfly.extension.elytron"/>
         <extension module="org.wildfly.extension.io"/>
     </extensions>
     <management>
@@ -69,7 +70,7 @@
         </access-control>
     </management>
     <profile>
-        <subsystem xmlns="urn:jboss:domain:logging:3.0">
+        <subsystem xmlns="urn:jboss:domain:logging:6.0">
             <console-handler name="CONSOLE">
                 <formatter>
                     <named-formatter name="##CONSOLE-FORMATTER##"/>
@@ -77,7 +78,7 @@
             </console-handler>
             <periodic-rotating-file-handler name="FILE" autoflush="true">
                 <formatter>
-                    <named-formatter name="PATTERN"/>
+                    <named-formatter name="COLOR-PATTERN"/>
                 </formatter>
                 <file relative-to="jboss.server.log.dir" path="server.log"/>
                 <suffix value=".yyyy-MM-dd"/>
@@ -117,22 +118,23 @@
                     <handler name="HR-ACCESS-FILE"/>
                 </handlers>
             </logger>
+            <!-- ##LOGGER_CONFIGURATION## -->
             <!-- ##ACCESS_LOG_HANDLER## -->
             <root-logger>
                 <level name="INFO"/>
                 <handlers>
                     <handler name="CONSOLE"/>
+                    <handler name="FILE"/>
                 </handlers>
             </root-logger>
             <formatter name="OPENSHIFT">
-                <custom-formatter module="org.jboss.logmanager.ext" class="org.jboss.logmanager.ext.formatters.LogstashFormatter">
-                    <properties>
-                        <property name="metaData" value="log-handler=CONSOLE"/>
-                    </properties>
-                </custom-formatter>
-            </formatter>
-            <formatter name="PATTERN">
-                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+                <json-formatter>
+                    <exception-output-type value="formatted"/>
+                    <key-overrides timestamp="@timestamp"/>
+                    <meta-data>
+                        <property name="@version" value="1"/>
+                    </meta-data>
+                </json-formatter>
             </formatter>
             <formatter name="COLOR-PATTERN">
                 <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>

--- a/openshift/datagrid-service/user-config/configuration/standalone.xml
+++ b/openshift/datagrid-service/user-config/configuration/standalone.xml
@@ -196,8 +196,8 @@
                     <protocol type="pbcast.STABLE"/>
                     <!-- ##JGROUPS_AUTH## -->
                     <protocol type="pbcast.GMS"/>
-                    <protocol type="UFC"/>
-                    <protocol type="MFC"/>
+                    <protocol type="UFC_NB"/>
+                    <protocol type="MFC_NB"/>
                     <protocol type="FRAG3"/>
                 </stack>
                 <stack name="tcp">
@@ -215,7 +215,7 @@
                     <protocol type="pbcast.STABLE"/>
                     <!-- ##JGROUPS_AUTH## -->
                     <protocol type="pbcast.GMS"/>
-                    <protocol type="MFC"/>
+                    <protocol type="MFC_NB"/>
                     <protocol type="FRAG3"/>
                 </stack>
             </stacks>


### PR DESCRIPTION
Adapt the standalone.xml configuration file in order to use the correct version of the logging subsystem and other minor modifications. Logging upgrade from version 3.0 to 6.0, replacement of the OPENSHIFT custom-formatter to use a JSON-formatter, replacement of the UFC and MFC with its non-blocking versions: UFC_NB and MFC_NB.

This PR fixes errors for DG 7.3.4, DG 7.3.5 and DG 7.3.6.

Changes for logging picked from https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/commit/5e4a218686da683456be15d084ed344c8bc7fbfb#diff-f137737731e7677038a757986b67f20d

Changes for non-blocking protocols cherry-picked from https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/commit/39236d714f75a5629debb60a5b4de32800cce378#diff-f137737731e7677038a757986b67f20dL187